### PR TITLE
Fix compiler warnings and turn on warnings as errors

### DIFF
--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -403,6 +403,12 @@ optional<lsTextEdit> BuildAutoImplementForFunction(QueryDatabase* db, WorkingFil
 
             break;
           }
+          case SymbolKind::Invalid:
+          case SymbolKind::File:
+          case SymbolKind::Type:
+            std::cerr << "Unexpected SymbolKind "
+                      << static_cast<int>(sym.idx.kind) << std::endl;
+            break;
         }
       }
 

--- a/src/project.cc
+++ b/src/project.cc
@@ -211,10 +211,10 @@ Project::Entry GetCompilationEntryFromCompileCommandEntry(
   return result;
 }
 
+/* TODO: Fix this function, it may be way faster than libclang's implementation.
 std::vector<Project::Entry> LoadFromCompileCommandsJson(
     std::unordered_set<std::string>& quote_includes, std::unordered_set<std::string>& angle_includes,
     const std::vector<std::string>& extra_flags, const std::string& project_directory) {
-  // TODO: Fix this function, it may be way faster than libclang's implementation.
 
   optional<std::string> compile_commands_content = ReadContent(project_directory + "/compile_commands.json");
   if (!compile_commands_content)
@@ -238,6 +238,7 @@ std::vector<Project::Entry> LoadFromCompileCommandsJson(
   }
   return result;
 }
+*/
 
 std::vector<Project::Entry> LoadFromDirectoryListing(
     std::unordered_set<std::string>& quote_includes, std::unordered_set<std::string>& angle_includes,

--- a/wscript
+++ b/wscript
@@ -130,7 +130,7 @@ def build(bld):
 
   bld.program(
       source=cc_files,
-      cxxflags=['-g', '-O3', '-std=c++11', '-Wall'],
+      cxxflags=['-g', '-O3', '-std=c++11', '-Wall', '-Werror'],
       includes=[
         'third_party/',
         'third_party/doctest/',


### PR DESCRIPTION
@jacobdufault please take a look.

I don't have a way to test on Windows or Mac, so it's possible there are other warnings on those platforms and -Werror will break them. Nonetheless it seems like good discipline.