### PR TITLE
Strip main source filename if it is a relative path in GetCompilationEntryFromCompileCommandEntry

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -114,7 +114,7 @@ Project::Entry GetCompilationEntryFromCompileCommandEntry(
         ++i;
         continue;
       }
-      if (StartsWithAny(arg, kBlacklist))
+      if (StartsWithAny(arg, kBlacklist) || arg == result.filename)
         continue;
     }
 


### PR DESCRIPTION
This partially fixes https://github.com/jacobdufault/cquery/issues/42, where relative paths are not recognized. Now both `compile_commands.json`s generated by bear/cmake work on my laptop.

Note `clang_parseTranslationUnit2FullArgv` called in `src/clang_translation_unit.cc` does not accept main source filename in `args`.

The comparison `arg == result.filename` is still hacky because it does not work if the `"file"` attribute in `compile_commands.json` is different from the argument appearing in `"arguments`" or `"command"`.


When a source file in the project is a symlink to another directory, `platform_linux.cc:NormalizePath` should not call `realpath(3)` because it resolves symlinks and in this case resolving is not desired.

Note. `canonicalize_filename_mode (const char *name, canonicalize_mode_t can_mode)` in gnulib `lib/canonicalize.c` can resolve a path without resolving symlinks.