### PR TITLE
Added waf option to use clang from system (--use-system-clang)

### DIFF
--- a/wscript
+++ b/wscript
@@ -61,6 +61,13 @@ cxx_compiler['linux'] = ['clang++', 'g++']
 
 def options(opt):
   opt.load('compiler_cxx')
+  grp = opt.add_option_group('Configuration options related to use of clang from the system (not recommended)')
+  grp.add_option('--use-system-clang', dest='use_system_clang', default=False, action='store_true',
+                 help='enable use of clang from the system')
+  grp.add_option('--llvm-config', dest='llvm_config', default='llvm-config',
+                 help='specify path to llvm-config for automatic configuration [default: %default]')
+  grp.add_option('--clang-prefix', dest='clang_prefix', default='',
+                 help='enable fallback configuration method by specifying a clang installation prefix (e.g. /opt/llvm)')
 
 def download_and_extract(destdir, dest, url):
   # Download and save the compressed tarball as |compressed_file_name|.
@@ -88,10 +95,46 @@ def configure(conf):
   conf.check(header_name='stdio.h', features='cxx cxxprogram', mandatory=True)
   conf.load('clang_compilation_database', tooldir='.')
 
-  print('Checking for clang')
-  download_and_extract(CLANG_DIRECTORY, CLANG_TARBALL_LOCAL_PATH, CLANG_TARBALL_URL)
-  #print('Checking for libcxx')
-  #download_and_extract(LIBCXX_DIRECTORY, LIBCXX_LOCAL_PATH, LIBCXX_URL)
+  if conf.options.use_system_clang:
+    # Ask llvm-config for cflags and ldflags
+    conf.find_program(conf.options.llvm_config, msg='checking for llvm-config', var='LLVM_CONFIG', mandatory=False)
+    if conf.env.LLVM_CONFIG:
+      conf.check_cfg(msg='Checking for clang flags',
+                    path=conf.env.LLVM_CONFIG,
+                    package='',
+                    uselib_store='clang',
+                    args='--cppflags --ldflags')
+      # llvm-config does not provide the actual library we want so we check for it
+      # using the provided info so far.
+      conf.check_cxx(lib='clang', uselib_store='clang', use='clang')
+
+    else: # Fallback method using a prefix path
+      conf.start_msg('Checking for clang prefix')
+      if not conf.options.clang_prefix:
+        raise conf.errors.ConfigurationError('not found (--clang-prefix must be specified when llvm-config is not found)')
+
+      prefix = conf.root.find_node(conf.options.clang_prefix)
+      if not prefix:
+        raise conf.errors.ConfigurationError('clang prefix not found: "%s"'%conf.options.clang_prefix)
+
+      conf.end_msg(prefix)
+
+      includes = [ n.abspath() for n in [ prefix.find_node('include') ] if n ]
+      libpath  = [ n.abspath() for n in [ prefix.find_node(l) for l in ('lib', 'lib64')] if n ]
+      conf.check_cxx(msg='Checking for library clang', lib='clang', uselib_store='clang', includes=includes, libpath=libpath)
+
+  else:
+    print('Checking for clang')
+    download_and_extract(CLANG_DIRECTORY, CLANG_TARBALL_LOCAL_PATH, CLANG_TARBALL_URL)
+    clang_node = conf.path.find_dir(CLANG_DIRECTORY)
+
+    conf.check_cxx(uselib_store='clang',
+                   includes=clang_node.find_dir('include').abspath(),
+                   libpath=clang_node.find_dir('lib').abspath(),
+                   lib='clang')
+
+  conf.msg('Clang includes', conf.env.INCLUDES_clang)
+  conf.msg('Clang library dir', conf.env.LIBPATH_clang)
 
   """
   # Download and save the compressed tarball as |compressed_file_name|.
@@ -117,16 +160,10 @@ def configure(conf):
 
 def build(bld):
   # todo: configure vars
-  CLANG_INCLUDE_DIR = '{0}/include'.format(CLANG_DIRECTORY)
-  CLANG_LIB_DIR = '{0}/lib'.format(CLANG_DIRECTORY)
-  CLANG_INCLUDE_DIR = os.path.abspath(CLANG_INCLUDE_DIR)
-  CLANG_LIB_DIR = os.path.abspath(CLANG_LIB_DIR)
-  print('CLANG_INCLUDE_DIR: {0}'.format(CLANG_INCLUDE_DIR))
-  print('CLANG_LIB_DIR:     {0}'.format(CLANG_LIB_DIR))
 
   cc_files = bld.path.ant_glob(['src/*.cc'])
 
-  lib = ['clang']
+  lib = []
   if sys.platform == 'linux' or sys.platform == 'linux2':
     lib.append('rt')
     lib.append('pthread')
@@ -136,6 +173,7 @@ def build(bld):
 
   bld.program(
       source=cc_files,
+      use='clang',
       cxxflags=['-g', '-O3', '-std=c++11', '-Wall', '-Werror'],
       includes=[
         'third_party/',
@@ -143,12 +181,9 @@ def build(bld):
         'third_party/loguru/',
         'third_party/rapidjson/include/',
         'third_party/sparsehash/src/',
-        'third_party/sparsepp/',
-        CLANG_INCLUDE_DIR],
+        'third_party/sparsepp/'],
       defines=['LOGURU_WITH_STREAMS=1'],
       lib=lib,
-      libpath=[CLANG_LIB_DIR],
-      rpath=[CLANG_LIB_DIR],
       target='app')
 
   #bld.shlib(source='a.cpp', target='mylib', vnum='9.8.7')


### PR DESCRIPTION
Using the option makes the assumption that `llvm-config` is in the path so that it can be probed for paths. I've tested it on Centos 7.2 with Clang 4.0.0 and it seems to work.