### PR TITLE
Only replace text if both rangeLength and range are not set

### DIFF
--- a/src/language_server_api.cc
+++ b/src/language_server_api.cc
@@ -273,6 +273,7 @@ bool lsPosition::operator==(const lsPosition& other) const {
 std::string lsPosition::ToString() const {
   return std::to_string(line) + ":" + std::to_string(character);
 }
+const lsPosition lsPosition::kZeroPosition = lsPosition();
 
 lsRange::lsRange() {}
 lsRange::lsRange(lsPosition start, lsPosition end) : start(start), end(end) {}

--- a/src/language_server_api.h
+++ b/src/language_server_api.h
@@ -148,6 +148,7 @@ struct lsPosition {
   // Note: these are 0-based.
   int line = 0;
   int character = 0;
+  static const lsPosition kZeroPosition;
 };
 MAKE_HASHABLE(lsPosition, t.line, t.character);
 MAKE_REFLECT_STRUCT(lsPosition, line, character);

--- a/src/working_files.cc
+++ b/src/working_files.cc
@@ -329,9 +329,8 @@ void WorkingFiles::OnChange(const Ipc_TextDocumentDidChange::Params& change) {
     // std::cerr << "|" << file->buffer_content << "|" << std::endl;
     // Per the spec replace everything if the rangeLength and range are not set.
     // See https://github.com/Microsoft/language-server-protocol/issues/9.
-    auto zeroPosition = lsPosition(0, 0);
-    if (diff.rangeLength == -1 && diff.range.start == zeroPosition
-        && diff.range.end == zeroPosition) {
+    if (diff.rangeLength == -1 && diff.range.start == lsPosition::kZeroPosition
+        && diff.range.end == lsPosition::kZeroPosition) {
       file->buffer_content = diff.text;
       file->OnBufferContentUpdated();
       // std::cerr << "-> Replacing entire content";


### PR DESCRIPTION
The wording in the protocol (https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textDocument_didChange) is "If range and rangeLength are omittted the new text is considered to be the full content of the document." Currently cquery replaces the full text when just rangeLength is omitted, but we could also compute the length here from the `end - start` to guard against lazy editors.