### PR TITLE
Remove whitespace before shebang in wscript

### DIFF
--- a/wscript
+++ b/wscript
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # encoding: utf-8
 
 try:


### PR DESCRIPTION
This makes the python extension in vscode recognize it as a python file