### PR TITLE
Use -Wno-sign-compare to make recent GCC happy

### DIFF
--- a/wscript
+++ b/wscript
@@ -136,7 +136,7 @@ def build(bld):
 
   bld.program(
       source=cc_files,
-      cxxflags=['-g', '-O3', '-std=c++11', '-Wall', '-Werror'],
+      cxxflags=['-g', '-O3', '-std=c++11', '-Wall', '-Wno-sign-compare', '-Werror'],
       includes=[
         'third_party/',
         'third_party/doctest/',


### PR DESCRIPTION
The combination of `-Wsign-compare` (brought by `-Wall`) and `-Werror` causes build failure when recent GCC (e.g. gcc 7) are used.