### PR TITLE
Catch ios_base::failure exceptions in ReadContent

### DIFF
--- a/src/utils.cc
+++ b/src/utils.cc
@@ -229,11 +229,13 @@ std::istream& SafeGetline(std::istream& is, std::string& t) {
 optional<std::string> ReadContent(const std::string& filename) {
   std::ifstream cache;
   cache.open(filename);
-  if (!cache.good())
-    return nullopt;
 
-  return std::string(std::istreambuf_iterator<char>(cache),
-                     std::istreambuf_iterator<char>());
+  try {
+    return std::string(std::istreambuf_iterator<char>(cache),
+                       std::istreambuf_iterator<char>());
+  } catch (std::ios_base::failure&) {
+    return nullopt;
+  }
 }
 
 std::vector<std::string> ReadLines(std::string filename) {


### PR DESCRIPTION
`filename` may be a directory (the latest Emacs lsp-mode sometimes sends a `textDocument/didOpen` message with an empty filename) or the file cannot be read. Note on Linux, a directory can be `open(2)`ed and the easiest way to catch this is to use a try catch.

There is some issue with the latest lsp-mode and it should be fixed.

The `querydb` thread should use a try ... catch ... because if it dies, the whole process dies. I am not familiar with the code base, but I think the check has its own merit.

