### PR TITLE
Make build.cmd a python script

### DIFF
--- a/vscode-client/build.cmd
+++ b/vscode-client/build.cmd
@@ -1,1 +1,0 @@
-vsce.cmd package -o ../vscode-extension.vsix

--- a/vscode-client/build.py
+++ b/vscode-client/build.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+import subprocess
+import sys
+
+if __name__ == "__main__":
+    vsce = 'vsce.cmd' if sys.platform == 'win32' else 'vsce'
+    sys.exit(subprocess.call([vsce, 'package', '-o', '../vscode-extension.vsix']))


### PR DESCRIPTION
This makes it easier to build the vscode plugin from windows or posix systems