### PR TITLE
Configurable EmitProgress methods

### DIFF
--- a/emacs/cquery.el
+++ b/emacs/cquery.el
@@ -65,6 +65,13 @@
   :type 'directory
   :group 'cquery)
 
+(defcustom cquery-indexer-count
+  0
+  "Number of workers cquery will use to index each project.
+ When left at 0, cquery will computer this value automatically."
+  :type 'number
+  :group 'cquery)
+
 (defface cquery-inactive-region-face
   '((t :foreground "#666666"))
   "The face used to mark inactive regions"
@@ -358,8 +365,11 @@
   (lsp-provide-marked-string-renderer client "c++" #'cquery--render-string))
 
 (defun cquery--get-init-params (workspace)
-  (list :cacheDirectory (concat (lsp--workspace-root workspace) cquery-cache-dir)
-        :resourceDirectory cquery-resource-dir))
+  (let ((json-false :json-false))
+    (list :cacheDirectory (concat (lsp--workspace-root workspace) cquery-cache-dir)
+          :resourceDirectory cquery-resource-dir
+          :indexerCount cquery-indexer-count
+          :enableProgressReports json-false))) ; TODO: prog reports for modeline
 
 (defun cquery--get-root ()
   "Return the root directory of a cquery project."

--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -796,16 +796,18 @@ struct IndexManager {
   }
 };
 
-// Sends indexing progress to client.
-void EmitProgress(QueueManager* queue) {
-  Out_Progress out;
-  out.params.indexRequestCount = queue->index_request.Size();
-  out.params.doIdMapCount = queue->do_id_map.Size();
-  out.params.loadPreviousIndexCount = queue->load_previous_index.Size();
-  out.params.onIdMappedCount = queue->on_id_mapped.Size();
-  out.params.onIndexedCount = queue->on_indexed.Size();
+// Send indexing progress to client if reporting is enabled.
+void EmitProgress(Config *config, QueueManager* queue) {
+  if (config->enableProgressReports) {
+    Out_Progress out;
+    out.params.indexRequestCount = queue->index_request.Size();
+    out.params.doIdMapCount = queue->do_id_map.Size();
+    out.params.loadPreviousIndexCount = queue->load_previous_index.Size();
+    out.params.onIdMappedCount = queue->on_id_mapped.Size();
+    out.params.onIndexedCount = queue->on_indexed.Size();
 
-  IpcManager::instance()->SendOutMessageToClient(IpcId::Cout, out);
+    IpcManager::instance()->SendOutMessageToClient(IpcId::Cout, out);
+  }
 }
 
 }  // namespace
@@ -1211,7 +1213,7 @@ WorkThread::Result IndexMain(Config* config,
                              WorkingFiles* working_files,
                              MultiQueueWaiter* waiter,
                              QueueManager* queue) {
-  EmitProgress(queue);
+  EmitProgress(config, queue);
 
   // TODO: dispose of index after it is not used for a while.
   ClangIndex index;
@@ -1256,7 +1258,7 @@ bool QueryDb_ImportMain(Config* config,
                         ImportManager* import_manager,
                         QueueManager* queue,
                         WorkingFiles* working_files) {
-  EmitProgress(queue);
+  EmitProgress(config, queue);
 
   bool did_work = false;
 

--- a/src/config.h
+++ b/src/config.h
@@ -36,6 +36,9 @@ struct Config {
   // If false, the index will not be loaded from a previous run.
   bool enableCacheRead = true;
 
+  // If true, cquery will send progress reports while indexing
+  bool enableProgressReports = true;
+
   // If true, document links are reported for #include directives.
   bool showDocumentLinksOnIncludes = true;
 
@@ -87,6 +90,7 @@ MAKE_REFLECT_STRUCT(Config,
                     enableIndexing,
                     enableCacheWrite,
                     enableCacheRead,
+                    enableProgressReports,
 
                     includeCompletionMaximumPathLength,
                     includeCompletionWhitelistLiteralEnding,


### PR DESCRIPTION
@topisani for the elisp, @jacobdufault for the C++

Also implements the `indexerCount` initialization option via a defcustom. Had it sitting in my index, figured I'd push it up.