### PR TITLE
Specify nullptr for source_filename in clang_parseTranslationUnit2

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ are skipped. Here's an example:
 
 ```
 # Language
--xc++
+clang++
 -std=c++11
 
 # Includes

--- a/src/clang_translation_unit.cc
+++ b/src/clang_translation_unit.cc
@@ -27,7 +27,7 @@ std::unique_ptr<ClangTranslationUnit> ClangTranslationUnit::Create(
 
   CXTranslationUnit cx_tu;
   CXErrorCode error_code = clang_parseTranslationUnit2FullArgv(
-      index->cx_index, filepath.c_str(), args.data(), (int)args.size(),
+      index->cx_index, nullptr, args.data(), (int)args.size(),
       unsaved_files.data(), (unsigned)unsaved_files.size(), flags, &cx_tu);
 
   switch (error_code) {


### PR DESCRIPTION
 so that we do not need to strip main source filename from args

Relevant lines in https://github.com/llvm-mirror/clang/blob/master/tools/libclang/CIndex.cpp :

```c++
  // The 'source_filename' argument is optional.  If the caller does not
  // specify it then it is assumed that the source file is specified
  // in the actual argument list.
  // Put the source file after command_line_args otherwise if '-x' flag is
  // present it will be unused.
  if (source_filename)
    Args->push_back(source_filename);
```

This is a better fit than b0e46df0741497dd52598e7917758257d8350637 and it also likely fixes https://github.com/jacobdufault/cquery/issues/67