### PR TITLE
Fix hang during reading from stdin

### DIFF
--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -3156,6 +3156,7 @@ void LanguageServerMain(const std::string& bin_name,
   QueueManager queue(waiter);
   std::unordered_map<IpcId, Timer> request_times;
 
+  std::cin.tie(NULL);
   LaunchStdinLoop(config, &request_times);
 
   // We run a dedicated thread for writing to stdout because there can be an


### PR DESCRIPTION
I experienced this hang problem when using cquery with
LanguageClient-neovim.

Sometimes std::cout would hang because the pipe is full, which would
normally be fine, since the client would read from the pipe soon.
However, in this case the client is blocking on a write(). This
shouldn't happen, because cquery has a stdin thread which constantly
reads from stdin. But, in C++, cin and cout are tied streams. Reading
from cin would cause cout to flush, which cause the read to block.

So, cquery can't write because the client doesn't read, the client won't
read before it finishes writing. It can't finish writing because cquery
can't read, and cquery can't read because cquery can't write. Which is a
deadlock.

The solution is to simply untie cin and cout.