### PR TITLE
Index file language and send it on hover

### DIFF
--- a/emacs/cquery.el
+++ b/emacs/cquery.el
@@ -362,7 +362,16 @@
 ;;  Register lsp client
 ;; ---------------------------------------------------------------------
 
-(defun cquery--render-string (str)
+(defun cquery--render-c-string (str)
+  (condition-case nil
+      (with-temp-buffer
+        (delay-mode-hooks (c-mode))
+        (insert str)
+        (font-lock-ensure)
+        (buffer-string))
+    (error str)))
+
+(defun cquery--render-c++-string (str)
   (condition-case nil
       (with-temp-buffer
         (delay-mode-hooks (c++-mode))
@@ -371,10 +380,21 @@
         (buffer-string))
     (error str)))
 
+(defun cquery--render-objc-string (str)
+  (condition-case nil
+      (with-temp-buffer
+        (delay-mode-hooks (objc-mode))
+        (insert str)
+        (font-lock-ensure)
+        (buffer-string))
+    (error str)))
+
 (defun cquery--initialize-client (client)
   (dolist (p cquery--handlers)
     (lsp-client-on-notification client (car p) (cdr p)))
-  (lsp-provide-marked-string-renderer client "c++" #'cquery--render-string))
+  (lsp-provide-marked-string-renderer client "c" #'cquery--render-c-string)
+  (lsp-provide-marked-string-renderer client "objc" #'cquery--render-objc-string)
+  (lsp-provide-marked-string-renderer client "c++" #'cquery--render-c++-string))
 
 (defun cquery--get-init-params (workspace)
   (let ((json-false :json-false))

--- a/emacs/cquery.el
+++ b/emacs/cquery.el
@@ -364,13 +364,11 @@
 
 (defun cquery--make-renderer (mode)
   `(lambda (str)
-     (condition-case nil
-         (with-temp-buffer
-           (delay-mode-hooks (,(intern "%s-mode" mode)))
-           (insert str)
-           (font-lock-ensure)
-           (buffer-string))
-       (error str))))
+     (with-temp-buffer
+       (delay-mode-hooks (,(intern (format "%s-mode" mode))))
+       (insert str)
+       (font-lock-ensure)
+       (buffer-string))))
 
 (defun cquery--initialize-client (client)
   (dolist (p cquery--handlers)
@@ -393,8 +391,8 @@
                         (user-error "Could not find cquery project root"))))
 
 (lsp-define-stdio-client
- (list cquery-executable "--language-server")
  lsp-cquery "cpp" #'cquery--get-root
+ (list cquery-executable "--language-server")
  :initialize #'cquery--initialize-client
  :extra-init-params #'cquery--get-init-params)
 

--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -2328,7 +2328,9 @@ bool QueryDbMainLoop(Config* config,
           if (!ls_range)
             continue;
 
-          response.result.contents = GetHoverForSymbol(db, ref.idx);
+          response.result.contents.value = GetHoverForSymbol(db, ref.idx);
+          response.result.contents.language = file->def->language;
+
           response.result.range = *ls_range;
           break;
         }

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1003,10 +1003,10 @@ void indexDeclaration(CXClientData client_data, const CXIdxDeclInfo* decl) {
     db->language = "c";
     break;
   case CXLanguage_CPlusPlus:
-    db->language = "c++";
+    db->language = "cpp";
     break;
   case CXLanguage_ObjC:
-    db->language = "objc";
+    db->language = "objectivec";
     break;
   case CXLanguage_Invalid:
     db->language = "invalid";

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -995,6 +995,24 @@ void indexDeclaration(CXClientData client_data, const CXIdxDeclInfo* decl) {
   if (!db)
     return;
 
+
+  // update the file language
+  // TODO: only do this when |is_first_ownership| in ConsumeFile is true
+  switch (clang_getCursorLanguage(decl->cursor)) {
+  case CXLanguage_C:
+    db->language = "c";
+    break;
+  case CXLanguage_CPlusPlus:
+    db->language = "c++";
+    break;
+  case CXLanguage_ObjC:
+    db->language = "objc";
+    break;
+  case CXLanguage_Invalid:
+    db->language = "invalid";
+    break;
+  }
+
   NamespaceHelper* ns = &param->ns;
 
   // std::cerr << "DECL kind=" << decl->entityInfo->kind << " at " <<

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -995,9 +995,8 @@ void indexDeclaration(CXClientData client_data, const CXIdxDeclInfo* decl) {
   if (!db)
     return;
 
-
   // The language of this declaration
-  LanguageId declLang = [decl] () {
+  LanguageId decl_lang = [decl] () {
       switch (clang_getCursorLanguage(decl->cursor)) {
       case CXLanguage_C:
         return LanguageId::C;
@@ -1011,8 +1010,8 @@ void indexDeclaration(CXClientData client_data, const CXIdxDeclInfo* decl) {
   } ();
 
   // Only update the file language if the new language is "greater" than the old
-  if (declLang > db->language) {
-    db->language = declLang;
+  if (decl_lang > db->language) {
+    db->language = decl_lang;
   }
 
   NamespaceHelper* ns = &param->ns;

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -996,21 +996,23 @@ void indexDeclaration(CXClientData client_data, const CXIdxDeclInfo* decl) {
     return;
 
 
-  // update the file language
-  // TODO: only do this when |is_first_ownership| in ConsumeFile is true
-  switch (clang_getCursorLanguage(decl->cursor)) {
-  case CXLanguage_C:
-    db->language = "c";
-    break;
-  case CXLanguage_CPlusPlus:
-    db->language = "cpp";
-    break;
-  case CXLanguage_ObjC:
-    db->language = "objectivec";
-    break;
-  case CXLanguage_Invalid:
-    db->language = "invalid";
-    break;
+  // The language of this declaration
+  LanguageId declLang = [decl] () {
+      switch (clang_getCursorLanguage(decl->cursor)) {
+      case CXLanguage_C:
+        return LanguageId::C;
+      case CXLanguage_CPlusPlus:
+        return LanguageId::Cpp;
+      case CXLanguage_ObjC:
+        return LanguageId::ObjC;
+      default:
+        return LanguageId::Unknown;
+      };
+  } ();
+
+  // Only update the file language if the new language is "greater" than the old
+  if (declLang > db->language) {
+    db->language = declLang;
   }
 
   NamespaceHelper* ns = &param->ns;

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -473,7 +473,8 @@ struct IndexFile {
   std::string path;
   std::vector<std::string> args;
   int64_t last_modification_time = 0;
-  // "c++", "c", "obj-c", "invalid" or "unknown"
+  // markdown compatible language identifier.
+  // "cpp", "c", "objectivec", or invalid"
   std::string language;
 
   // The path to the translation unit cc file which caused the creation of this

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -473,6 +473,8 @@ struct IndexFile {
   std::string path;
   std::vector<std::string> args;
   int64_t last_modification_time = 0;
+  // "c++", "c", "obj-c", "invalid" or "unknown"
+  std::string language;
 
   // The path to the translation unit cc file which caused the creation of this
   // IndexFile. When parsing a translation unit we generate many IndexFile

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -473,7 +473,6 @@ enum class LanguageId {
   Cpp = 2,
   ObjC = 3
 };
-
 MAKE_REFLECT_TYPE_PROXY(LanguageId, std::underlying_type<LanguageId>::type);
 
 struct IndexFile {

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -464,6 +464,18 @@ struct IndexInclude {
   std::string resolved_path;
 };
 
+// Used to identify the language at a file level. The ordering is important, as
+// a file previously identified as `C`, will be changed to `Cpp` if it
+// encounters a c++ declaration.
+enum class LanguageId {
+  Unknown = 0,
+  C = 1,
+  Cpp = 2,
+  ObjC = 3
+};
+
+MAKE_REFLECT_TYPE_PROXY(LanguageId, std::underlying_type<LanguageId>::type);
+
 struct IndexFile {
   IdCache id_cache;
 
@@ -473,9 +485,7 @@ struct IndexFile {
   std::string path;
   std::vector<std::string> args;
   int64_t last_modification_time = 0;
-  // markdown compatible language identifier.
-  // "cpp", "c", "objectivec", or invalid"
-  std::string language;
+  LanguageId language = LanguageId::Unknown;
 
   // The path to the translation unit cc file which caused the creation of this
   // IndexFile. When parsing a translation unit we generate many IndexFile

--- a/src/language_server_api.h
+++ b/src/language_server_api.h
@@ -1179,6 +1179,24 @@ MAKE_REFLECT_STRUCT(lsSignatureHelp,
                     signatures,
                     activeSignature,
                     activeParameter);
+
+// MarkedString can be used to render human readable text. It is either a markdown string
+// or a code-block that provides a language and a code snippet. The language identifier
+// is sematically equal to the optional language identifier in fenced code blocks in GitHub
+// issues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+//
+// The pair of a language and a value is an equivalent to markdown:
+// ```${language}
+// ${value}
+// ```
+//
+// Note that markdown strings will be sanitized - that means html will be escaped.
+struct lsMarkedString {
+  std::string language;
+  std::string value;
+};
+MAKE_REFLECT_STRUCT(lsMarkedString, language, value);
+
 struct Out_TextDocumentSignatureHelp
     : public lsOutMessage<Out_TextDocumentSignatureHelp> {
   lsRequestId id;
@@ -1228,7 +1246,7 @@ struct Ipc_TextDocumentHover : public IpcMessage<Ipc_TextDocumentHover> {
 MAKE_REFLECT_STRUCT(Ipc_TextDocumentHover, id, params);
 struct Out_TextDocumentHover : public lsOutMessage<Out_TextDocumentHover> {
   struct Result {
-    std::string contents;
+    lsMarkedString contents;
     optional<lsRange> range;
   };
 

--- a/src/query.cc
+++ b/src/query.cc
@@ -171,9 +171,22 @@ void CompareGroups(std::vector<T>& previous_data,
 QueryFile::Def BuildFileDef(const IdMap& id_map, const IndexFile& indexed) {
   QueryFile::Def def;
   def.path = indexed.path;
-  def.language = indexed.language;
   def.includes = indexed.includes;
   def.inactive_regions = indexed.skipped_by_preprocessor;
+
+  // Convert enum to markdown compatible strings
+  def.language = [indexed] () {
+      switch (indexed.language) {
+      case LanguageId::C:
+        return "c";
+      case LanguageId::Cpp:
+        return "cpp";
+      case LanguageId::ObjC:
+        return "objectivec";
+      default:
+        return "";
+      }
+    } ();
 
   auto add_outline = [&def, &id_map](SymbolIdx idx, Range range) {
     def.outline.push_back(SymbolRef(idx, id_map.ToQuery(range)));

--- a/src/query.cc
+++ b/src/query.cc
@@ -171,6 +171,7 @@ void CompareGroups(std::vector<T>& previous_data,
 QueryFile::Def BuildFileDef(const IdMap& id_map, const IndexFile& indexed) {
   QueryFile::Def def;
   def.path = indexed.path;
+  def.language = indexed.language;
   def.includes = indexed.includes;
   def.inactive_regions = indexed.skipped_by_preprocessor;
 

--- a/src/query.h
+++ b/src/query.h
@@ -169,6 +169,8 @@ void Reflect(TVisitor& visitor, MergeableUpdate<TId, TValue>& value) {
 struct QueryFile {
   struct Def {
     std::string path;
+    // Language identifier
+    std::string language;
     // Includes in the file.
     std::vector<IndexInclude> includes;
     // Outline of the file (ie, for code lens).
@@ -191,6 +193,7 @@ struct QueryFile {
 };
 MAKE_REFLECT_STRUCT(QueryFile::Def,
                     path,
+                    language,
                     outline,
                     all_symbols,
                     inactive_regions);

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -169,6 +169,7 @@ void Reflect(TVisitor& visitor, IndexFile& value) {
   if (!gTestOutputMode) {
     REFLECT_MEMBER(version);
     REFLECT_MEMBER(last_modification_time);
+    REFLECT_MEMBER(language);
     REFLECT_MEMBER(import_file);
     REFLECT_MEMBER(args);
   }


### PR DESCRIPTION
This allows hover strings to have syntax highlighting

Currently it breaks hover in vscode (with nothing logged), and makes emacs emit the infamous `(error No Content-Length header)`