### PR TITLE
Remove function advice around codeAction callback.

### DIFF
--- a/emacs/cquery.el
+++ b/emacs/cquery.el
@@ -396,14 +396,5 @@
  :initialize #'cquery--initialize-client
  :extra-init-params #'cquery--get-init-params)
 
-;; ---------------------------------------------------------------------
-;;  lsp-mode function advices
-;; ---------------------------------------------------------------------
-
-;; For some reason this function just adds code actions in lsp-mode. We need to
-;; clear the old ones
-(advice-add 'lsp--text-document-code-action-callback :around
-            '(lambda (orig actions) (setq lsp-code-actions actions)))
-
 (provide 'cquery)
 ;;; cquery.el ends here


### PR DESCRIPTION
Old code action objects are now cleared (https://github.com/emacs-lsp/lsp-mode/commit/85442531315e826922362d0d545ddf9fc8653346), so the advice is no longer needed. 

Plus, the callback function for `codeAction` is a dynamically generated closure, so `lsp--text-document-code-action-callback` no longer exists.