### PR TITLE
Don't highlight operators as functions

### DIFF
--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -171,6 +171,8 @@ void EmitSemanticHighlighting(QueryDatabase* db,
         QueryFunc* func = &db->funcs[sym.idx.idx];
         if (!func->def)
           continue;  // applies to for loop
+        if (func->def->is_operator)
+          continue; // applies to for loop
         is_type_member = func->def->declaring_type.has_value();
         break;
       }

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1188,6 +1188,12 @@ void indexDeclaration(CXClientData client_data, const CXIdxDeclInfo* decl) {
       if (!is_template_specialization) {
         func->def.short_name = decl->entityInfo->name;
 
+        // Set the |is_operator| flag
+        // clang must have this information somewhere, but i've been unable to
+        // find it. Feel free to replace this hackish code if you do
+        //  - topisani
+        func->def.is_operator = func->def.short_name.compare(0, 8, "operator") == 0;
+
         // Build detailed name. The type desc looks like void (void *). We
         // insert the qualified name before the first '('.
         std::string qualified_name =

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1188,10 +1188,7 @@ void indexDeclaration(CXClientData client_data, const CXIdxDeclInfo* decl) {
       if (!is_template_specialization) {
         func->def.short_name = decl->entityInfo->name;
 
-        // Set the |is_operator| flag
-        // clang must have this information somewhere, but i've been unable to
-        // find it. Feel free to replace this hackish code if you do
-        //  - topisani
+        // Set the |is_operator| flag to true if the function name starts with "operator"
         func->def.is_operator = func->def.short_name.compare(0, 8, "operator") == 0;
 
         // Build detailed name. The type desc looks like void (void *). We

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -267,6 +267,9 @@ struct FuncDefDefinitionData {
   // Functions that this function calls.
   std::vector<FuncRef> callees;
 
+  // Used for semantic highlighting
+  bool is_operator;
+
   FuncDefDefinitionData() {}  // For reflection.
   FuncDefDefinitionData(const std::string& usr) : usr(usr) {
     // assert(usr.size() > 0);
@@ -308,6 +311,7 @@ void Reflect(
   REFLECT_MEMBER(base);
   REFLECT_MEMBER(locals);
   REFLECT_MEMBER(callees);
+  REFLECT_MEMBER(is_operator);
   REFLECT_MEMBER_END();
 }
 

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -268,7 +268,7 @@ struct FuncDefDefinitionData {
   std::vector<FuncRef> callees;
 
   // Used for semantic highlighting
-  bool is_operator;
+  bool is_operator = false;
 
   FuncDefDefinitionData() {}  // For reflection.
   FuncDefDefinitionData(const std::string& usr) : usr(usr) {

--- a/src/query.cc
+++ b/src/query.cc
@@ -50,6 +50,7 @@ optional<QueryFunc::DefUpdate> ToQuery(const IdMap& id_map,
   result.base = id_map.ToQuery(func.base);
   result.locals = id_map.ToQuery(func.locals);
   result.callees = id_map.ToQuery(func.callees);
+  result.is_operator = func.is_operator;
   return result;
 }
 

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -118,6 +118,7 @@ template <typename TVisitor>
 void Reflect(TVisitor& visitor, IndexFunc& value) {
   REFLECT_MEMBER_START();
   REFLECT_MEMBER2("id", value.id);
+  REFLECT_MEMBER2("is_operator", value.def.is_operator);
   REFLECT_MEMBER2("usr", value.def.usr);
   REFLECT_MEMBER2("short_name", value.def.short_name);
   REFLECT_MEMBER2("detailed_name", value.def.detailed_name);


### PR DESCRIPTION
indexes `is_operator` for functions. Currently this is achieved by simply checking if `short_name` starts with `operator`, but there must be a better way, even though i searched the clang docs for a long time.

Also, i am not sure if its the best aproach to simply not highlight operators at all, but it looks a lot better:
![image](https://user-images.githubusercontent.com/3133596/33483992-c453bb26-d6a0-11e7-91cd-a5b88a035664.png)
Before, `operator==` was all yellow.

this fixes one part of #103 