### PR TITLE
Group cache files by projectRoot

### DIFF
--- a/src/cache.cc
+++ b/src/cache.cc
@@ -10,14 +10,19 @@
 
 namespace {
 
-std::string GetCachedBaseFileName(const std::string& cache_directory,
-                                  std::string source_file) {
-  assert(!cache_directory.empty());
-  std::replace(source_file.begin(), source_file.end(), '\\', '_');
-  std::replace(source_file.begin(), source_file.end(), '/', '_');
-  std::replace(source_file.begin(), source_file.end(), ':', '_');
+std::string GetCachedBaseFileName(Config* config,
+                                  const std::string& source_file,
+                                  bool create_dir = false) {
+  assert(!config->cacheDirectory.empty());
+  std::string cache_file;
+  size_t len = config->projectRoot.size();
+  if (StartsWith(source_file, config->projectRoot)) {
+    cache_file = EscapeFileName(config->projectRoot) + '/' +
+      EscapeFileName(source_file.substr(len));
+  } else
+    cache_file = EscapeFileName(source_file);
 
-  return cache_directory + source_file;
+  return config->cacheDirectory + cache_file;
 }
 
 }  // namespace
@@ -28,7 +33,7 @@ std::unique_ptr<IndexFile> LoadCachedIndex(Config* config,
     return nullptr;
 
   optional<std::string> file_content = ReadContent(
-      GetCachedBaseFileName(config->cacheDirectory, filename) + ".json");
+      GetCachedBaseFileName(config, filename) + ".json");
   if (!file_content)
     return nullptr;
 
@@ -40,7 +45,7 @@ optional<std::string> LoadCachedFileContents(Config* config,
   if (!config->enableCacheRead)
     return nullopt;
 
-  return ReadContent(GetCachedBaseFileName(config->cacheDirectory, filename));
+  return ReadContent(GetCachedBaseFileName(config, filename));
 }
 
 void WriteToCache(Config* config, IndexFile& file) {
@@ -48,7 +53,7 @@ void WriteToCache(Config* config, IndexFile& file) {
     return;
 
   std::string cache_basename =
-      GetCachedBaseFileName(config->cacheDirectory, file.path);
+      GetCachedBaseFileName(config, file.path);
 
   if (file.file_contents_.empty()) {
     LOG_S(ERROR) << "No cached file contents; performing potentially stale "

--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -1474,7 +1474,6 @@ bool QueryDbMainLoop(Config* config,
 
           config->cacheDirectory = NormalizePath(config->cacheDirectory);
           EnsureEndsInSlash(config->cacheDirectory);
-          MakeDirectoryRecursive(config->cacheDirectory);
 
           // Ensure there is a resource directory.
           if (config->resourceDirectory.empty()) {
@@ -1553,6 +1552,8 @@ bool QueryDbMainLoop(Config* config,
           config->projectRoot =
               NormalizePath(request->params.rootUri->GetPath());
           EnsureEndsInSlash(config->projectRoot);
+          MakeDirectoryRecursive(
+              config->cacheDirectory + EscapeFileName(config->projectRoot));
 
           // Start indexer threads.
           if (config->indexerCount == 0) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -195,6 +195,15 @@ void EnsureEndsInSlash(std::string& path) {
     path += '/';
 }
 
+std::string EscapeFileName(std::string path) {
+  if (path.size() && path.back() == '/')
+    path.pop_back();
+  std::replace(path.begin(), path.end(), '\\', '_');
+  std::replace(path.begin(), path.end(), '/', '_');
+  std::replace(path.begin(), path.end(), ':', '_');
+  return path;
+}
+
 // http://stackoverflow.com/a/6089413
 std::istream& SafeGetline(std::istream& is, std::string& t) {
   t.clear();

--- a/src/utils.h
+++ b/src/utils.h
@@ -69,6 +69,10 @@ void GetFilesInFolder(std::string folder,
 // Ensures that |path| ends in a slash.
 void EnsureEndsInSlash(std::string& path);
 
+// Converts a file path to one that can be used as filename.
+// e.g. foo/bar.c => foo_bar.c
+std::string EscapeFileName(std::string path);
+
 optional<std::string> ReadContent(const std::string& filename);
 std::vector<std::string> ReadLines(std::string filename);
 std::vector<std::string> ToLines(const std::string& content,


### PR DESCRIPTION
ext4's H(alfbaked B+) tree has a severe limitation: directory inode size never shrinks.

```
% stat -c 'inode size: %s' cquery_cached_index
inode size: 69632
% rm cquery_cached_index/*
% stat -c 'inode size: %s' cquery_cached_index
inode size: 69632
```

Flat cache directory makes it hard to delete files of a project, i.e. `rm cquery_cache/_your_project_*` may not work because it may exceed maximum argument length (`xargs --show-limits`, https://unix.stackexchange.com/questions/120642/what-defines-the-maximum-size-for-a-command-single-argument https://www.in-ulm.de/~mascheck/various/argmax/)

With this commit, users can use `rm -r cquery_cache/_your_project/` to remove all cache files of a project.

Windows seems to use `/` for `"file"` attribute in `compile_commands.json`.

If you do not want to re-index your project, you can use the following command to move files to the new directory:
```zsh
# Please change $f, remove 'echo'
f=_usr_include
mkdir $f
for i in ${f}_*; do echo mv $i $f/${i##${f}_}; done
```