### PR TITLE
Ensure that paths passed to libclang are fully expanded

### DIFF
--- a/emacs/cquery.el
+++ b/emacs/cquery.el
@@ -381,7 +381,7 @@
   (let ((json-false :json-false))
     (list :cacheDirectory (file-name-as-directory
                            (expand-file-name cquery-cache-dir (lsp--workspace-root workspace)))
-          :resourceDirectory cquery-resource-dir
+          :resourceDirectory (expand-file-name cquery-resource-dir)
           :indexerCount cquery-indexer-count
           :enableProgressReports json-false))) ; TODO: prog reports for modeline
 

--- a/src/project.cc
+++ b/src/project.cc
@@ -63,7 +63,7 @@ static std::vector<std::string> kBlacklist = {
 static std::vector<std::string> kPathArgs = {
     "-I",        "-iquote",        "-isystem",     "--sysroot=",
     "-isysroot", "-gcc-toolchain", "-include-pch", "-iframework",
-    "-F",        "-imacros"};
+    "-F",        "-imacros",       "-include"};
 
 // Arguments whose path arguments should be injected into include dir lookup
 // for #include completion.


### PR DESCRIPTION
Ran into these two issues while playing around with my config. With this patch:

1. `-include` directives in arg lists now resolve out properly. 
  Before this patch:

`Creating completion session with arguments cc [SNIP] -I/home/josh/Upstream/linux/include/generated/uapi, -include, ./include/linux/kconfig.h, [SNIP]`

  After:
``Creating completion session with arguments cc [SNIP] -I/home/josh/Upstream/linux/include/generated/uapi, -include, /home/josh/Upstream/linux/include/linux/kconfig.h, [SNIP]`

2. The `clang_resource_dir` supplied by cquery.el's  initParams would silently fail to do anything useful, littering diagnostics with "size_t is not defined" errors.