### PR TITLE
Serialize clang_createIndex to prevent race condition (concurrent modify/read to FirstTarget defined in lib/Support/TargetRegistry.cpp)

### DIFF
--- a/src/clang_index.cc
+++ b/src/clang_index.cc
@@ -1,9 +1,18 @@
 #include "clang_index.h"
 
+#include <mutex>
+
 ClangIndex::ClangIndex() : ClangIndex(1, 0) {}
 
 ClangIndex::ClangIndex(int exclude_declarations_from_pch,
                        int display_diagnostics) {
+  // llvm::InitializeAllTargets (and possibly others) called by clang_createIndex
+  // transtively modifies/reads lib/Support/TargetRegistry.cpp FirstTarget.
+  // There will be a race condition if two threads call clang_createIndex
+  // concurrently.
+  static std::mutex mutex_;
+  std::lock_guard<std::mutex> lock(mutex_);
+
   cx_index =
       clang_createIndex(exclude_declarations_from_pch, display_diagnostics);
 }

--- a/src/clang_translation_unit.cc
+++ b/src/clang_translation_unit.cc
@@ -14,16 +14,6 @@
 
 namespace {
 
-// We need to serialize requests to clang_parseTranslationUnit2FullArgv and
-// clang_reparseTranslationUnit. See
-// https://github.com/jacobdufault/cquery/issues/43#issuecomment-347614504.
-//
-// NOTE: This is disabled because it effectively serializes indexing, as a huge
-// chunk of indexing time is spent inside of these functions.
-//
-// std::mutex g_parse_translation_unit_mutex;
-// std::mutex g_reparse_translation_unit_mutex;
-
 void EmitDiagnostics(std::string path,
                      std::vector<const char*> args,
                      CXTranslationUnit tu) {
@@ -95,7 +85,6 @@ std::unique_ptr<ClangTranslationUnit> ClangTranslationUnit::Create(
   CXTranslationUnit cx_tu;
   CXErrorCode error_code;
   {
-    // std::lock_guard<std::mutex> lock(g_parse_translation_unit_mutex);
     error_code = clang_parseTranslationUnit2FullArgv(
         index->cx_index, filepath.c_str(), args.data(), (int)args.size(),
         unsaved_files.data(), (unsigned)unsaved_files.size(), flags, &cx_tu);
@@ -134,7 +123,6 @@ std::unique_ptr<ClangTranslationUnit> ClangTranslationUnit::Reparse(
     std::vector<CXUnsavedFile>& unsaved) {
   int error_code;
   {
-    // std::lock_guard<std::mutex> lock(g_reparse_translation_unit_mutex);
     error_code = clang_reparseTranslationUnit(
         tu->cx_tu, (unsigned)unsaved.size(), unsaved.data(),
         clang_defaultReparseOptions(tu->cx_tu));


### PR DESCRIPTION
Hopefully fixes https://github.com/jacobdufault/cquery/issues/43

`RegisterTarget` modifies a global variable `FirstTarget` which may be concurrently read by other threads that are calling `clang_createIndex`.

```
(gdb) bt                    
#0  0x00007fd5ac25d280 in llvm::TargetRegistry::RegisterTarget(llvm::Target&, char const*, char const*, bool (*)(llvm::Triple::ArchType), bool) ()
   from /home/maskray/Dev/Util/cquery/build/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/lib/libclang.so.5
#1  0x00007fd5ab8fd5d8 in LLVMInitializeAArch64TargetInfo ()                                                      
   from /home/maskray/Dev/Util/cquery/build/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/lib/libclang.so.5
#2  0x00007fd5aae90a86 in llvm::InitializeAllTargets() ()                                                         
   from /home/maskray/Dev/Util/cquery/build/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/lib/libclang.so.5
#3  0x00007fd5aae908de in clang_createIndex ()           
   from /home/maskray/Dev/Util/cquery/build/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/lib/libclang.so.5
#4  0x000055bd41986583 in ClangIndex::ClangIndex (this=0x7fd5a27fbd78, exclude_declarations_from_pch=1, 
    display_diagnostics=0) at ../src/clang_index.cc:8    
#5  0x000055bd4198655e in ClangIndex::ClangIndex (this=0x7fd5a27fbd78) at ../src/clang_index.cc:3
#6  0x000055bd4198d31a in IndexMain (config=0x55bd4333ea90, file_consumer_shared=0x7ffeaa7e75b0, 
    timestamp_manager=0x7ffeaa7e71f0, import_manager=0x7ffeaa7e7250, project=0x7ffeaa7e7670, 
    working_files=0x7ffeaa7e7610, waiter=0x7ffeaa7e7f10, queue=0x7ffeaa7e7a40) at ../src/command_line.cc:509
#7  0x000055bd41a4864c in (anonymous namespace)::InitializeHandler::<lambda()>::operator()(void) const (
    __closure=0x55bd43341ac8) at ../src/messages/initialize.cc:175                                                
#8  0x000055bd41a4a7bb in std::_Function_handler<WorkThread::Result(), (anonymous namespace)::InitializeHandler::Run((anonymous namespace)::Ipc_InitializeRequest*)::<lambda()> >::_M_invoke(const std::_Any_data &) (
    __functor=...) at /usr/include/c++/6/functional:1717 
#9  0x000055bd41b4ec12 in std::function<WorkThread::Result ()>::operator()() const (this=0x55bd43341ac8)
    at /usr/include/c++/6/functional:2127                
#10 0x000055bd41b4e4ee in WorkThread::<lambda()>::operator()(void) const (__closure=0x55bd43341aa8)
    at ../src/work_thread.cc:18                          
#11 0x000055bd41b4eb78 in std::_Bind_simple<WorkThread::StartThread(const string&, const std::function<WorkThread::Result()>&)::<lambda()>()>::_M_invoke<>(std::_Index_tuple<>) (this=0x55bd43341aa8)
    at /usr/include/c++/6/functional:1391                
#12 0x000055bd41b4eb15 in std::_Bind_simple<WorkThread::StartThread(const string&, const std::function<WorkThread::Result()>&)::<lambda()>()>::operator()(void) (this=0x55bd43341aa8) at /usr/include/c++/6/functional:1380
#13 0x000055bd41b4eaf4 in std::thread::_State_impl<std::_Bind_simple<WorkThread::StartThread(const string&, const std::function<WorkThread::Result()>&)::<lambda()>()> >::_M_run(void) (this=0x55bd43341aa0)
    at /usr/include/c++/6/thread:197                     
#14 0x00007fd5aa771e6f in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
```