### PR TITLE
Reflect empty string

### DIFF
--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -67,8 +67,6 @@ void Reflect(Writer& visitor, std::string& value) {
 
 // ReflectMember
 void ReflectMember(Writer& visitor, const char* name, std::string& value) {
-  if (value.empty())
-    return;
   visitor.Key(name);
   Reflect(visitor, value);
 }


### PR DESCRIPTION
MarkedString::value is a mandatory field and the client may complain if `value` does not exist.

Emacs lsp-mode sometimes complains about `textDocument/hover` responses because `language` is non-empty but `value` is empty.