### PR TITLE
More idiomatic

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1657,8 +1657,10 @@ std::vector<std::unique_ptr<IndexFile>> ParseWithTu(
     // Update dependencies for the file. Do not include the file in its own
     // dependency set.
     entry->dependencies = param.seen_files;
-    entry->dependencies.erase(std::find(
-        entry->dependencies.begin(), entry->dependencies.end(), entry->path));
+    entry->dependencies.erase(
+        std::remove(entry->dependencies.begin(), entry->dependencies.end(),
+                    entry->path),
+        entry->dependencies.end());
 
     // Make sure we are using correct file contents.
     for (const CXUnsavedFile& contents : file_contents) {
@@ -1694,14 +1696,12 @@ void ClangSanityCheck() {
                                 void* reserved) -> CXIdxClientFile {
     return nullptr;
   };
-  callback.ppIncludedFile =
-      [](CXClientData client_data,
-         const CXIdxIncludedFileInfo* file) -> CXIdxClientFile {
-    return nullptr;
-  };
-  callback.importedASTFile =
-      [](CXClientData client_data,
-         const CXIdxImportedASTFileInfo*) -> CXIdxClientASTFile {
+  callback.ppIncludedFile = [](
+      CXClientData client_data,
+      const CXIdxIncludedFileInfo* file) -> CXIdxClientFile { return nullptr; };
+  callback.importedASTFile = [](
+      CXClientData client_data,
+      const CXIdxImportedASTFileInfo*) -> CXIdxClientASTFile {
     return nullptr;
   };
   callback.startedTranslationUnit = [](CXClientData client_data,

--- a/src/utils.h
+++ b/src/utils.h
@@ -98,8 +98,7 @@ std::unique_ptr<T> MakeUnique(Args&&... args) {
 
 template <typename T>
 void AddRange(std::vector<T>* dest, const std::vector<T>& to_add) {
-  for (const T& e : to_add)
-    dest->push_back(e);
+  dest->insert(dest->end(), to_add.begin(), to_add.end());
 }
 
 template <typename T>


### PR DESCRIPTION
```diff
-    entry->dependencies.erase(std::find(
-        entry->dependencies.begin(), entry->dependencies.end(), entry->path));
+    entry->dependencies.erase(
+        std::remove(entry->dependencies.begin(), entry->dependencies.end(),
+                    entry->path),
+        entry->dependencies.end());
```
`a.erase(a.end())` is undefined behavior, but this is not an issue if `dependencies` is guaranteed to include `entry->path`. This is just safer.

`a.erase(a.end(), a.end()` is defined.

See http://en.cppreference.com/w/cpp/container/vector/erase