### PR TITLE
Escape more symbols in path handling.

### DIFF
--- a/src/language_server_api.cc
+++ b/src/language_server_api.cc
@@ -223,9 +223,13 @@ void lsDocumentUri::SetPath(const std::string& path) {
                     "%3A");
   }
 
+  // subset of reserved characters from the URI standard
+  // http://www.ecma-international.org/ecma-262/6.0/#sec-uri-syntax-and-semantics
   raw_uri = ReplaceAll(raw_uri, " ", "%20");
   raw_uri = ReplaceAll(raw_uri, "(", "%28");
   raw_uri = ReplaceAll(raw_uri, ")", "%29");
+  raw_uri = ReplaceAll(raw_uri, "#", "%23");
+  raw_uri = ReplaceAll(raw_uri, ",", "%2C");
 
 // TODO: proper fix
 #if defined(_WIN32)


### PR DESCRIPTION
Add escapes for "#" and "," because buck build tool use them to differentiate target patterns in its generated compile_commands.json: [source](https://github.com/facebook/buck/blob/91ca77c2e44e494132075390a36ac16dd27a2dbb/src/com/facebook/buck/model/AbstractBuildTarget.java#L100-L111).
I considered covering the other cases from the [standard](http://www.ecma-international.org/ecma-262/6.0/#sec-uri-syntax-and-semantics), but decided against it because of the potential of extra string allocations if I add too many cases.