### PR TITLE
Change default path of built executable from build/app to build/relea…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,19 @@ Building cquery is simple. The external dependencies are few:
 $ clang --version  # if missing, sudo apt-get install clang
 $ git clone https://github.com/jacobdufault/cquery --recursive
 $ cd cquery
-$ ./waf configure
+$ ./waf configure --prefix ~/.local/stow/cquery
 $ ./waf build
+# -g -O3, built build/release/bin/cquery
+$ ./waf install
+# optional, copies the executable to $PREFIX/bin/cquery
+```
+
+For a debug build:
+
+```bash
+$ ./waf configure --variant=debug
+$ ./waf build --variant=debug
+# -g -O0, built build/debug/bin/cquery
 ```
 
 ## Install extension

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -98,12 +98,12 @@
         "cquery.launch.workingDirectory": {
           "type": "string",
           "default": "",
-          "description": "Path to the directory which contains the cquery binary (ie, if cquery is checkout out at /work/cquery/ then this directory is /work/cquery/build)"
+          "description": "Path to the directory which contains the cquery binary (ie, if cquery is checkout out at /work/cquery/ then this directory is /work/cquery/build/release/)"
         },
         "cquery.launch.command": {
           "type": "string",
-          "default": "./app",
-          "description": "Command to start the cquery binary (on Linux ./app, on Windows indexer.exe)"
+          "default": "bin/cquery",
+          "description": "Command to start the cquery binary (on Linux bin/cquery, on Windows bin/indexer.exe)"
         },
         "cquery.launch.autoRestart": {
           "type": "boolean",

--- a/wscript
+++ b/wscript
@@ -50,8 +50,7 @@ def options(opt):
                  help='specify path to llvm-config for automatic configuration [default: %default]')
   grp.add_option('--clang-prefix', dest='clang_prefix', default='',
                  help='enable fallback configuration method by specifying a clang installation prefix (e.g. /opt/llvm)')
-  # TODO Default to 'release' and disallow empty variant
-  grp.add_option('--variant', default='',
+  grp.add_option('--variant', default='release',
                  help='variant name for saving configuration and build results. Variants other than "debug" turn on -O3')
 
 def download_and_extract(destdir, url):
@@ -199,7 +198,7 @@ def build(bld):
       defines=['LOGURU_WITH_STREAMS=1'],
       lib=lib,
       rpath=[] if bld.env['use_system_clang'] else bld.env['LIBPATH_clang'],
-      target='app')
+      target='bin/cquery')
 
   #bld.shlib(source='a.cpp', target='mylib', vnum='9.8.7')
   #bld.shlib(source='a.cpp', target='mylib2', vnum='9.8.7', cnum='9.8')


### PR DESCRIPTION
…se/bin/cquery (installed to $PREFIX/bin/cquery)

This is incompatible, please change your editor configuration:

* LanguageClient-neovim: g:LanguageClient_serverCommands
* Emacs cquery.el: cquery-executable
* VSCode: cquery.launch.workingDirectory cquery.launch.command


Haven't set up my VSCode... so `.vsix`...