### PR TITLE
In OnIndexDeclaration, get_type_description() may return the name of …

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1161,8 +1161,13 @@ void OnIndexDeclaration(CXClientData client_data, const CXIdxDeclInfo* decl) {
             ns->QualifiedName(decl->semanticContainer, func->def.short_name);
         std::string type_desc = decl_cursor.get_type_description();
         size_t offset = type_desc.find('(');
-        type_desc.insert(offset, qualified_name);
-        func->def.detailed_name = type_desc;
+        if (offset != std::string::npos) {
+          type_desc.insert(offset, qualified_name);
+          func->def.detailed_name = type_desc;
+        } else {
+          // type_desc is probably the name of a typedef.
+          func->def.detailed_name = type_desc + " " + qualified_name;
+        }
 
         // Add function usage information. We only want to do it once per
         // definition/declaration. Do it on definition since there should only


### PR DESCRIPTION
…a typedef and there is no (, causing `insert` failing