### PR TITLE
Better default resource dir heuristics: use system resource dir with …

### DIFF
--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -86,12 +86,15 @@ struct InitializeHandler : BaseMessageHandler<Ipc_InitializeRequest> {
 
       // Ensure there is a resource directory.
       if (config->resourceDirectory.empty()) {
-        config->resourceDirectory = GetWorkingDirectory();
-#if defined(_WIN32)
-        config->resourceDirectory += std::string("../../clang_resource_dir/");
-#else
-        config->resourceDirectory += std::string("../clang_resource_dir/");
-#endif
+        std::string defaultResourceDirectory = std::string(DEFAULT_RESOURCE_DIRECTORY);
+        if (defaultResourceDirectory.find("..") != std::string::npos) {
+          std::string executablePath = GetExecutablePath();
+          size_t pos = executablePath.find_last_of('/');
+          config->resourceDirectory = executablePath.substr(0, pos+1);
+          config->resourceDirectory += defaultResourceDirectory;
+        } else {
+          config->resourceDirectory = defaultResourceDirectory;
+        }
       }
       config->resourceDirectory = NormalizePath(config->resourceDirectory);
       LOG_S(INFO) << "Using -resource-dir=" << config->resourceDirectory;

--- a/src/platform.h
+++ b/src/platform.h
@@ -31,6 +31,7 @@ std::unique_ptr<PlatformSharedMemory> CreatePlatformSharedMemory(
 
 void PlatformInit();
 
+std::string GetExecutablePath();
 std::string GetWorkingDirectory();
 std::string NormalizePath(const std::string& path);
 // Creates a directory at |path|. Creates directories recursively if needed.

--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -210,6 +210,27 @@ std::unique_ptr<PlatformSharedMemory> CreatePlatformSharedMemory(
 
 void PlatformInit() {}
 
+#ifdef __APPLE__
+extern "C" int _NSGetExecutablePath(char* buf,uint32_t* bufsize);
+#endif
+
+// See https://stackoverflow.com/questions/143174/how-do-i-get-the-directory-that-a-program-is-running-from
+std::string GetExecutablePath() {
+#ifndef __APPLE__
+  char buffer[PATH_MAX+1] = {0};
+  readlink("/proc/self/exe", buffer, PATH_MAX);
+  return std::string(buffer);
+#else
+  uint32_t size = 0;
+  _NSGetExecutablePath(nullptr, &size);
+  char *buffer = new char[size];
+  _NSGetExecutablePath(buffer, &size);
+  std::string result(buffer);
+  delete[] buffer;
+  return result;
+#endif
+}
+
 std::string GetWorkingDirectory() {
   char result[FILENAME_MAX];
   if (!getcwd(result, sizeof(result)))

--- a/src/platform_win.cc
+++ b/src/platform_win.cc
@@ -127,6 +127,13 @@ void PlatformInit() {
   _setmode(_fileno(stdin), O_BINARY);
 }
 
+// See https://stackoverflow.com/questions/143174/how-do-i-get-the-directory-that-a-program-is-running-from
+std::string GetExecutablePath() {
+  char result[MAX_PATH] = {0};
+  GetModuleFileName(NULL, result, MAX_PATH);
+  return std::string(result);
+}
+
 // See http://stackoverflow.com/a/19535628
 std::string GetWorkingDirectory() {
   char result[MAX_PATH];


### PR DESCRIPTION
…system clang and relative path to resource dir with bundled clang.

See issue #135 and #136 for the reason behind this PR.

Windows and Linux platforms are not tested. My computer is macOS.