### PR TITLE
Use ${workspaceFolder} instead of absolute path for cacheDirectory

### DIFF
--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -118,7 +118,7 @@
         "cquery.cacheDirectory": {
           "type": "string",
           "default": "",
-          "description": "Absolute path to the directory that the cached index will be stored in. Try to have this directory on an SSD. If not explicitly set, this will be automatically populated with the extension cache directory.\n\nCache directories are project-wide, so this should be configured in the workspace settings so multiple indexes do not clash.\n\nExample value: \"/work/cquery-cache/chrome/\""
+          "description": "Absolute path to the directory that the cached index will be stored in. Try to have this directory on an SSD. If not explicitly set, this will be automatically populated with the extension cache directory.\n\n${workspaceFolder} will be replaced by the folder where .vscode/settings.json resides.\n\nCache directories are project-wide, so this should be configured in the workspace settings so multiple indexes do not clash.\n\nExample value: \"/work/cquery-cache/chrome/\""
         },
         "cquery.highlighting.enabled.types": {
           "type": "boolean",

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -105,16 +105,12 @@ function getClientConfig(context: ExtensionContext) {
     // Provide a default cache directory if it is not present. Insert next to
     // the project since if the user has an SSD they most likely have their
     // source files on the SSD as well.
-    const generateCacheDirectory = () => {
-      let workspaceDir = workspace.rootPath.replace(/\\/g, '/');
-      if (!workspaceDir.endsWith('/'))
-        workspaceDir += '/';
-      return workspaceDir + '.vscode/cquery_cached_index/'
-    };
-    let cacheDir = generateCacheDirectory();
+    let cacheDir = '${workspaceFolder}/.vscode/cquery_cached_index/';
     clientConfig.cacheDirectory = cacheDir;
     config.update(kCacheDirPrefName, cacheDir, false /*global*/);
   }
+  clientConfig.cacheDirectory = clientConfig.cacheDirectory.replace(
+      '${workspaceFolder}', workspace.rootPath);
 
   return clientConfig;
 }


### PR DESCRIPTION
I have my `.vscode/settings.json` file checked into Git, because I have some project specific `"search.exclude"` and `"files.exclude"` settings there. The cquery extension adds `"cquery.cacheDirectory"` there with an absolute path, which results in conflicts when using the repository on different locations at the same time.

This will change the default to `'${workspaceFolder}/.vscode/cquery_cached_index/'` and replace the variable everytime the configuration is loaded. I've chosen `${workspaceFolder}` since that's what tasks.json also uses: https://code.visualstudio.com/docs/editor/tasks#_variable-substitution