### PR TITLE
Fix IsSymLink on Linux

### DIFF
--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -335,7 +335,7 @@ bool IsSymLink(const std::string& path) {
   struct stat buf;
   int result;
   result = lstat(path.c_str(), &buf);
-  return result == 0;
+  return S_ISLNK(buf.st_mode);
 }
 
 std::vector<std::string> GetPlatformClangArguments() {


### PR DESCRIPTION
IsSymlink was giving faulty results when finding recursive files on Linux. I've updated the function to use the built-in POSIX macro for checking if a file is a symlink.

https://linux.die.net/man/2/lstat