### PR TITLE
set rpath for mac when --use-system-clang

### DIFF
--- a/wscript
+++ b/wscript
@@ -242,7 +242,10 @@ def build(bld):
   # Fallback for windows
   default_resource_directory = os.path.join(os.getcwd(), 'clang_resource_dir')
   if bld.env['use_system_clang']:
-    rpath = []
+    if sys.platform == 'darwin':
+      rpath = bld.env['LIBPATH_clang'][0]
+    else:
+      rpath = []
 
     devnull = '/dev/null' if sys.platform != 'win32' else 'NUL'
     output = subprocess.check_output(['clang', '-###', '-xc', devnull], stderr=subprocess.STDOUT).decode()


### PR DESCRIPTION
My target codebase requires clang 5.0, but didn't want to use the bundled 5.0 since it isn't recommended due to a bug.  So, I downloaded llvm trunk and built it myself and used it when building cquery via:
`./waf configure --variant=system --use-system-clang --llvm-config=/mydir/llvm-build/bin/llvm-config`

when running the resulting binary, though, i would get:
```
dyld: Library not loaded: @rpath/libclang.dylib
  Referenced from: /Users/joel/git-3rd-party-repos/cquery/build/release/bin/cquery
  Reason: image not found
Abort trap: 6
```

After reading up on `@rpath`, it seems we need to specify the `-rpath` when building a binary on mac, i.e. `rpath` has no system default like on linux/freebsd.  With this patch, everything works correctly for me, at least.