### PR TITLE
[indexer] Index references to system headers

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1357,13 +1357,6 @@ bool IsFunctionCallContext(CXCursorKind kind) {
 }
 
 void OnIndexReference(CXClientData client_data, const CXIdxEntityRefInfo* ref) {
-  // Don't index references from or to system headers.
-  if (clang_Location_isInSystemHeader(
-          clang_indexLoc_getCXSourceLocation(ref->loc)) ||
-      clang_Location_isInSystemHeader(
-          clang_getCursorLocation(ref->referencedEntity->cursor)))
-    return;
-
   // TODO: Use clang_getFileUniqueID
   CXFile file;
   clang_getSpellingLocation(clang_indexLoc_getCXSourceLocation(ref->loc), &file,


### PR DESCRIPTION
```c
#include <unistd.h>
int main() {
  fsync(0); /// hover on `fsync`, invoke textDocument/definitions
}
```

Before: nothing happens
After: jump to fsync declaration in unistd.h


Note, a system header may be shared by different projects and currently the cache filename for it is the same for different projects. We may need to differentiate among projects.

The disk usage is not an issue. I don't see difference of cacheDirectory size before/after this commit.
```
du -sh /tmp/cquery
356K
```