### PR TITLE
[indexer] Treat explicit destructor call as not `is_implicit`

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1443,6 +1443,10 @@ void OnIndexReference(CXClientData client_data, const CXIdxEntityRefInfo* ref) {
       // or implicit), but libclang only supports implicit for objective-c.
       bool is_implicit =
           CanBeCalledImplicitly(ref->referencedEntity->kind) &&
+          // For explicit destructor call, ref->cursor may be "~" while called->def.short_name is "~A"
+          // "~A" is not a substring of ref->cursor, but we should take this case as not `is_implicit`.
+          called->def.short_name.size() && called->def.short_name[0] != '~' &&
+
           !CursorSpellingContainsString(ref->cursor, param->tu->cx_tu,
                                         called->def.short_name);
 

--- a/src/platform_posix.cc
+++ b/src/platform_posix.cc
@@ -342,9 +342,7 @@ out_error:
 
 bool IsSymLink(const std::string& path) {
   struct stat buf;
-  int result;
-  result = lstat(path.c_str(), &buf);
-  return S_ISLNK(buf.st_mode);
+  return lstat(path.c_str(), &buf) == 0 && S_ISLNK(buf.st_mode);
 }
 
 std::vector<std::string> GetPlatformClangArguments() {


### PR DESCRIPTION
struct A {
  ~A() {}
};
int main() {
  A *a;
  a->~A();   /// hover on `~`, call textDocument/definitions
}

Before: nothing happens
After: jump to `~A() {}`