### PR TITLE
/.cquery file parsing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,14 @@ can add the flags to a file called `.cquery` located in the top-level
 workspace directory.
 
 Each argument in that file is separated by a newline. Lines starting with `#`
-are skipped. Here's an example:
+are skipped. The first line can optionally be the path to the intended compiler,
+which can help if the standard library paths are relative to the binary.
+Here's an example:
 
 ```
+# Driver
+/usr/bin/clang++-4.0
+
 # Language
 -xc++
 -std=c++11

--- a/src/project.cc
+++ b/src/project.cc
@@ -511,6 +511,14 @@ TEST_SUITE("Project") {
          "-Wno-unknown-warning-option"});
   }
 
+  TEST_CASE("Implied binary") {
+    CheckFlags("/home/user", "/home/user/foo/bar.cc",
+        /* raw */ {"-DDONT_IGNORE_ME"},
+        /* expected */ {"clang++", "-DDONT_IGNORE_ME", "-xc++", "-std=c++11",
+                        "-resource-dir=/w/resource_dir/",
+                        "-Wno-unknown-warning-option"});
+  }
+
   // Checks flag parsing for a random chromium file in comparison to what
   // YouCompleteMe fetches.
   TEST_CASE("ycm") {


### PR DESCRIPTION
- relative include path handling
- first line was being ignored if it was a flag (code assumed it was path to clang binary)