### PR TITLE
For textDocument/hover, do not error on empty results

### DIFF
--- a/src/messages/text_document_hover.cc
+++ b/src/messages/text_document_hover.cc
@@ -82,14 +82,6 @@ struct TextDocumentHoverHandler : BaseMessageHandler<Ipc_TextDocumentHover> {
       break;
     }
 
-    if (out.result.contents.value.empty()) {
-      Out_Error out;
-      out.id = request->id;
-      out.error.code = lsErrorCodes::InternalError;
-      IpcManager::WriteStdout(IpcId::Unknown, out);
-      return;
-    }
-
     IpcManager::WriteStdout(IpcId::TextDocumentHover, out);
   }
 };


### PR DESCRIPTION
`textDocument/hover` is usually called by editors whenever the cursor moves. For example, Emacs lsp-mode sets `eldoc-documentation-function` to `lsp--on-hover` which is invoked automatically. The error message is undesired.