### PR TITLE
[indexer] Handle unnamed namespaces

### DIFF
--- a/src/clang_cursor.h
+++ b/src/clang_cursor.h
@@ -85,3 +85,12 @@ class ClangCursor {
 
   CXCursor cx_cursor;
 };
+
+namespace std {
+template <>
+struct hash<ClangCursor> {
+  size_t operator()(const ClangCursor& x) const {
+    return clang_hashCursor(x.cx_cursor);
+  }
+};
+}


### PR DESCRIPTION
```
namespace b{
  namespace{
    namespace a{
      void e(); // Before a::e   After   b::(anon)::a::e
      namespace{
        namespace{
          void f(); // Before: ::f  After: b::(anon)::a::(anon)::(anon)::f
        }
      }
    }
  }
}
```