### PR TITLE
[indexer] Make $cquery/base find correct overriden functions

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1211,7 +1211,9 @@ void OnIndexDeclaration(CXClientData client_data, const CXIdxDeclInfo* decl) {
                                      &num_overridden);
 
           for (unsigned i = 0; i < num_overridden; ++i) {
-            ClangCursor parent = overridden[i];
+            ClangCursor parent =
+                ClangCursor(overridden[i])
+                    .template_specialization_to_template_definition();
             IndexFuncId parent_id = db->ToFuncId(parent.get_usr());
             IndexFunc* parent_def = db->Resolve(parent_id);
             func = db->Resolve(func_id);  // ToFuncId invalidated func_def


### PR DESCRIPTION
`$cquery/base` could not locate overriden functions from template classes. This is caused by the lack of `         .template_specialization_to_template_definition()`.


```c++
template <class T>
struct B0 {
  virtual void foo() {}
};

template <class T>
struct B1 {
  virtual void bar() {}
};

template <>
struct B1<int> {
  virtual void bar() {}
};

struct A : B0<int>, B1<int> {
  // Before no action (a function named B0<int>::foo is instantiated but it does not have position info)
  // After $cquery/base jumps to B0<T>::foo
  void foo() override {}
  // Before jumps to B1<int>::bar
  // After same
  void bar() override {}
};
```