### PR TITLE
Add experimental command line option --enable-comments to index comments and display them on textDocument/hover

### DIFF
--- a/src/clang_cursor.cc
+++ b/src/clang_cursor.cc
@@ -5,6 +5,9 @@
 #include <algorithm>
 #include <cassert>
 
+// TODO Place this global variable into config
+bool g_enable_comments = false;
+
 ClangType::ClangType() : cx_type() {}
 
 ClangType::ClangType(const CXType& other) : cx_type(other) {}
@@ -183,14 +186,19 @@ std::string ClangCursor::get_type_description() const {
 }
 
 optional<std::string> ClangCursor::get_comments() const {
-  return nullopt;
-  // TODO
+  if (!g_enable_comments)
+    return nullopt;
   ClangCursor referenced = get_referenced();
-  if (referenced)
-    // Get unformatted comments. Returns multiple paragraphs.
-    return ::ToString(clang_Cursor_getRawCommentText(referenced.cx_cursor));
-  // Get formatted comments. Returns only the first paragraph.
-  return ::ToString(clang_Cursor_getBriefCommentText(referenced.cx_cursor));
+  // TODO Format comments
+  std::string ret =
+      referenced
+          // Get unformatted comments. Returns multiple paragraphs.
+          ? ::ToString(clang_Cursor_getRawCommentText(referenced.cx_cursor))
+          // Get formatted comments. Returns only the first paragraph.
+          : ::ToString(clang_Cursor_getBriefCommentText(referenced.cx_cursor));
+  if (ret.empty())
+    return nullopt;
+  return ret;
 }
 
 std::string ClangCursor::ToString() const {

--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -439,6 +439,12 @@ int main(int argc, char** argv) {
     RunIndexTests(options["--test-index"]);
   }
 
+  if (HasOption(options, "--enable-comments")) {
+    // TODO Place this global variable into config
+    extern bool g_enable_comments;
+    g_enable_comments = true;
+  }
+
   if (HasOption(options, "--language-server")) {
     print_help = false;
     // std::cerr << "Running language server" << std::endl;


### PR DESCRIPTION
It uses a global variable `g_enable_comments` in `clang_cursor.cc` which should be placed somewhere else.

@romix 
`build/debug/bin/cquery --language-server --enable-comments`