### PR TITLE
Add --use-clang-cxx to waf and move type printer to src/type_printer.cc

### DIFF
--- a/libclang/CIndexDiagnostic.h
+++ b/libclang/CIndexDiagnostic.h
@@ -1,0 +1,165 @@
+/*===-- CIndexDiagnostic.h - Diagnostics C Interface ------------*- C++ -*-===*\
+|*                                                                            *|
+|*                     The LLVM Compiler Infrastructure                       *|
+|*                                                                            *|
+|* This file is distributed under the University of Illinois Open Source      *|
+|* License. See LICENSE.TXT for details.                                      *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* Implements the diagnostic functions of the Clang C interface.              *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CINDEXDIAGNOSTIC_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CINDEXDIAGNOSTIC_H
+
+#include "clang-c/Index.h"
+#include <memory>
+#include <vector>
+#include <assert.h>
+
+namespace clang {
+
+class LangOptions;
+class StoredDiagnostic;
+class CXDiagnosticImpl;
+  
+class CXDiagnosticSetImpl {
+  std::vector<std::unique_ptr<CXDiagnosticImpl>> Diagnostics;
+  const bool IsExternallyManaged;
+public:
+  CXDiagnosticSetImpl(bool isManaged = false)
+    : IsExternallyManaged(isManaged) {}
+
+  virtual ~CXDiagnosticSetImpl();
+
+  size_t getNumDiagnostics() const {
+    return Diagnostics.size();
+  }
+  
+  CXDiagnosticImpl *getDiagnostic(unsigned i) const {
+    assert(i < getNumDiagnostics());
+    return Diagnostics[i].get();
+  }
+
+  void appendDiagnostic(std::unique_ptr<CXDiagnosticImpl> D);
+
+  bool empty() const {
+    return Diagnostics.empty();
+  }
+  
+  bool isExternallyManaged() const { return IsExternallyManaged; }
+};
+
+class CXDiagnosticImpl {
+public:
+  enum Kind { StoredDiagnosticKind, LoadedDiagnosticKind,
+              CustomNoteDiagnosticKind };
+  
+  virtual ~CXDiagnosticImpl();
+  
+  /// \brief Return the severity of the diagnostic.
+  virtual CXDiagnosticSeverity getSeverity() const = 0;
+  
+  /// \brief Return the location of the diagnostic.
+  virtual CXSourceLocation getLocation() const = 0;
+
+  /// \brief Return the spelling of the diagnostic.
+  virtual CXString getSpelling() const = 0;
+
+  /// \brief Return the text for the diagnostic option.
+  virtual CXString getDiagnosticOption(CXString *Disable) const = 0;
+  
+  /// \brief Return the category of the diagnostic.
+  virtual unsigned getCategory() const = 0;
+
+  /// \brief Return the category string of the diagnostic.
+  virtual CXString getCategoryText() const = 0;
+
+  /// \brief Return the number of source ranges for the diagnostic.
+  virtual unsigned getNumRanges() const = 0;
+  
+  /// \brief Return the source ranges for the diagnostic.
+  virtual CXSourceRange getRange(unsigned Range) const = 0;
+
+  /// \brief Return the number of FixIts.
+  virtual unsigned getNumFixIts() const = 0;
+
+  /// \brief Return the FixIt information (source range and inserted text).
+  virtual CXString getFixIt(unsigned FixIt,
+                            CXSourceRange *ReplacementRange) const = 0;
+
+  Kind getKind() const { return K; }
+  
+  CXDiagnosticSetImpl &getChildDiagnostics() {
+    return ChildDiags;
+  }
+  
+protected:
+  CXDiagnosticImpl(Kind k) : K(k) {}
+  CXDiagnosticSetImpl ChildDiags;
+
+  void append(std::unique_ptr<CXDiagnosticImpl> D) {
+    ChildDiags.appendDiagnostic(std::move(D));
+  }
+  
+private:
+  Kind K;
+};
+  
+/// \brief The storage behind a CXDiagnostic
+struct CXStoredDiagnostic : public CXDiagnosticImpl {
+  const StoredDiagnostic &Diag;
+  const LangOptions &LangOpts;
+  
+  CXStoredDiagnostic(const StoredDiagnostic &Diag,
+                     const LangOptions &LangOpts)
+    : CXDiagnosticImpl(StoredDiagnosticKind),
+      Diag(Diag), LangOpts(LangOpts) { }
+
+  ~CXStoredDiagnostic() override {}
+
+  /// \brief Return the severity of the diagnostic.
+  CXDiagnosticSeverity getSeverity() const override;
+
+  /// \brief Return the location of the diagnostic.
+  CXSourceLocation getLocation() const override;
+
+  /// \brief Return the spelling of the diagnostic.
+  CXString getSpelling() const override;
+
+  /// \brief Return the text for the diagnostic option.
+  CXString getDiagnosticOption(CXString *Disable) const override;
+
+  /// \brief Return the category of the diagnostic.
+  unsigned getCategory() const override;
+
+  /// \brief Return the category string of the diagnostic.
+  CXString getCategoryText() const override;
+
+  /// \brief Return the number of source ranges for the diagnostic.
+  unsigned getNumRanges() const override;
+
+  /// \brief Return the source ranges for the diagnostic.
+  CXSourceRange getRange(unsigned Range) const override;
+
+  /// \brief Return the number of FixIts.
+  unsigned getNumFixIts() const override;
+
+  /// \brief Return the FixIt information (source range and inserted text).
+  CXString getFixIt(unsigned FixIt,
+                    CXSourceRange *ReplacementRange) const override;
+
+  static bool classof(const CXDiagnosticImpl *D) {
+    return D->getKind() == StoredDiagnosticKind;
+  }
+};
+
+namespace cxdiag {
+CXDiagnosticSetImpl *lazyCreateDiags(CXTranslationUnit TU,
+                                     bool checkIfChanged = false);
+} // end namespace cxdiag
+
+} // end namespace clang
+
+#endif

--- a/libclang/CIndexer.h
+++ b/libclang/CIndexer.h
@@ -1,0 +1,155 @@
+//===- CIndexer.h - Clang-C Source Indexing Library -------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines CIndexer, a subclass of Indexer that provides extra
+// functionality needed by the CIndex library.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CINDEXER_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CINDEXER_H
+
+#include "clang-c/Index.h"
+#include "clang/Frontend/PCHContainerOperations.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Mutex.h"
+#include <utility>
+
+namespace llvm {
+  class CrashRecoveryContext;
+}
+
+namespace clang {
+class ASTUnit;
+class MacroInfo;
+class MacroDefinitionRecord;
+class SourceLocation;
+class Token;
+class IdentifierInfo;
+
+class CIndexer {
+  bool OnlyLocalDecls;
+  bool DisplayDiagnostics;
+  unsigned Options; // CXGlobalOptFlags.
+
+  std::string ResourcesPath;
+  std::shared_ptr<PCHContainerOperations> PCHContainerOps;
+
+  std::string ToolchainPath;
+
+  std::string InvocationEmissionPath;
+
+public:
+  CIndexer(std::shared_ptr<PCHContainerOperations> PCHContainerOps =
+               std::make_shared<PCHContainerOperations>())
+      : OnlyLocalDecls(false), DisplayDiagnostics(false),
+        Options(CXGlobalOpt_None), PCHContainerOps(std::move(PCHContainerOps)) {
+  }
+
+  /// \brief Whether we only want to see "local" declarations (that did not
+  /// come from a previous precompiled header). If false, we want to see all
+  /// declarations.
+  bool getOnlyLocalDecls() const { return OnlyLocalDecls; }
+  void setOnlyLocalDecls(bool Local = true) { OnlyLocalDecls = Local; }
+  
+  bool getDisplayDiagnostics() const { return DisplayDiagnostics; }
+  void setDisplayDiagnostics(bool Display = true) {
+    DisplayDiagnostics = Display;
+  }
+
+  std::shared_ptr<PCHContainerOperations> getPCHContainerOperations() const {
+    return PCHContainerOps;
+  }
+
+  unsigned getCXGlobalOptFlags() const { return Options; }
+  void setCXGlobalOptFlags(unsigned options) { Options = options; }
+
+  bool isOptEnabled(CXGlobalOptFlags opt) const {
+    return Options & opt;
+  }
+
+  /// \brief Get the path of the clang resource files.
+  const std::string &getClangResourcesPath();
+
+  StringRef getClangToolchainPath();
+
+  void setInvocationEmissionPath(StringRef Str) {
+    InvocationEmissionPath = Str;
+  }
+
+  StringRef getInvocationEmissionPath() const { return InvocationEmissionPath; }
+};
+
+/// Logs information about a particular libclang operation like parsing to
+/// a new file in the invocation emission path.
+class LibclangInvocationReporter {
+public:
+  enum class OperationKind { ParseOperation, CompletionOperation };
+
+  LibclangInvocationReporter(CIndexer &Idx, OperationKind Op,
+                             unsigned ParseOptions,
+                             llvm::ArrayRef<const char *> Args,
+                             llvm::ArrayRef<std::string> InvocationArgs,
+                             llvm::ArrayRef<CXUnsavedFile> UnsavedFiles);
+  ~LibclangInvocationReporter();
+
+private:
+  std::string File;
+};
+
+  /// \brief Return the current size to request for "safety".
+  unsigned GetSafetyThreadStackSize();
+
+  /// \brief Set the current size to request for "safety" (or 0, if safety
+  /// threads should not be used).
+  void SetSafetyThreadStackSize(unsigned Value);
+
+  /// \brief Execution the given code "safely", using crash recovery or safety
+  /// threads when possible.
+  ///
+  /// \return False if a crash was detected.
+  bool RunSafely(llvm::CrashRecoveryContext &CRC, llvm::function_ref<void()> Fn,
+                 unsigned Size = 0);
+
+  /// \brief Set the thread priority to background.
+  /// FIXME: Move to llvm/Support.
+  void setThreadBackgroundPriority();
+
+  /// \brief Print libclang's resource usage to standard error.
+  void PrintLibclangResourceUsage(CXTranslationUnit TU);
+
+  namespace cxindex {
+    void printDiagsToStderr(ASTUnit *Unit);
+
+    /// \brief If \c MacroDefLoc points at a macro definition with \c II as
+    /// its name, this retrieves its MacroInfo.
+    MacroInfo *getMacroInfo(const IdentifierInfo &II,
+                            SourceLocation MacroDefLoc, CXTranslationUnit TU);
+
+    /// \brief Retrieves the corresponding MacroInfo of a MacroDefinitionRecord.
+    const MacroInfo *getMacroInfo(const MacroDefinitionRecord *MacroDef,
+                                  CXTranslationUnit TU);
+
+    /// \brief If \c Loc resides inside the definition of \c MI and it points at
+    /// an identifier that has ever been a macro name, this returns the latest
+    /// MacroDefinitionRecord for that name, otherwise it returns NULL.
+    MacroDefinitionRecord *checkForMacroInMacroDefinition(const MacroInfo *MI,
+                                                          SourceLocation Loc,
+                                                          CXTranslationUnit TU);
+
+    /// \brief If \c Tok resides inside the definition of \c MI and it points at
+    /// an identifier that has ever been a macro name, this returns the latest
+    /// MacroDefinitionRecord for that name, otherwise it returns NULL.
+    MacroDefinitionRecord *checkForMacroInMacroDefinition(const MacroInfo *MI,
+                                                          const Token &Tok,
+                                                          CXTranslationUnit TU);
+    }
+    }
+
+#endif

--- a/libclang/CLog.h
+++ b/libclang/CLog.h
@@ -1,0 +1,103 @@
+//===- CLog.h - Logging Interface -------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CLOG_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CLOG_H
+
+#include "clang-c/Index.h"
+#include "clang/Basic/LLVM.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/raw_ostream.h"
+#include <string>
+
+namespace llvm {
+class format_object_base;
+}
+
+namespace clang {
+  class FileEntry;
+
+namespace cxindex {
+
+class Logger;
+typedef IntrusiveRefCntPtr<Logger> LogRef;
+
+/// \brief Collects logging output and writes it to stderr when it's destructed.
+/// Common use case:
+/// \code
+///   if (LogRef Log = Logger::make(__func__)) {
+///     *Log << "stuff";
+///   }
+/// \endcode
+class Logger : public RefCountedBase<Logger> {
+  std::string Name;
+  bool Trace;
+  SmallString<64> Msg;
+  llvm::raw_svector_ostream LogOS;
+public:
+  static const char *getEnvVar() {
+    static const char *sCachedVar = ::getenv("LIBCLANG_LOGGING");
+    return sCachedVar;
+  }
+  static bool isLoggingEnabled() { return getEnvVar() != nullptr; }
+  static bool isStackTracingEnabled() {
+    if (const char *EnvOpt = Logger::getEnvVar())
+      return llvm::StringRef(EnvOpt) == "2";
+    return false;
+  }
+  static LogRef make(llvm::StringRef name,
+                     bool trace = isStackTracingEnabled()) {
+    if (isLoggingEnabled())
+      return new Logger(name, trace);
+    return nullptr;
+  }
+
+  explicit Logger(llvm::StringRef name, bool trace)
+    : Name(name), Trace(trace), LogOS(Msg) { }
+  ~Logger();
+
+  Logger &operator<<(CXTranslationUnit);
+  Logger &operator<<(const FileEntry *FE);
+  Logger &operator<<(CXCursor cursor);
+  Logger &operator<<(CXSourceLocation);
+  Logger &operator<<(CXSourceRange);
+  Logger &operator<<(CXString);
+  Logger &operator<<(llvm::StringRef Str) { LogOS << Str; return *this; }
+  Logger &operator<<(const char *Str) {
+    if (Str)
+      LogOS << Str;
+    return *this;
+  }
+  Logger &operator<<(unsigned long N) { LogOS << N; return *this; }
+  Logger &operator<<(long N) { LogOS << N ; return *this; }
+  Logger &operator<<(unsigned int N) { LogOS << N; return *this; }
+  Logger &operator<<(int N) { LogOS << N; return *this; }
+  Logger &operator<<(char C) { LogOS << C; return *this; }
+  Logger &operator<<(unsigned char C) { LogOS << C; return *this; }
+  Logger &operator<<(signed char C) { LogOS << C; return *this; }
+  Logger &operator<<(const llvm::format_object_base &Fmt);
+};
+
+}
+}
+
+/// \brief Macros to automate common uses of Logger. Like this:
+/// \code
+///   LOG_FUNC_SECTION {
+///     *Log << "blah";
+///   }
+/// \endcode
+#define LOG_SECTION(NAME) \
+    if (clang::cxindex::LogRef Log = clang::cxindex::Logger::make(NAME))
+#define LOG_FUNC_SECTION LOG_SECTION(__func__)
+
+#endif

--- a/libclang/CXComment.h
+++ b/libclang/CXComment.h
@@ -1,0 +1,64 @@
+//===- CXComment.h - Routines for manipulating CXComments -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines routines for manipulating CXComments.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CXCOMMENT_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CXCOMMENT_H
+
+#include "CXTranslationUnit.h"
+#include "clang-c/Documentation.h"
+#include "clang-c/Index.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Comment.h"
+#include "clang/Frontend/ASTUnit.h"
+
+namespace clang {
+namespace comments {
+  class CommandTraits;
+}
+
+namespace cxcomment {
+
+static inline CXComment createCXComment(const comments::Comment *C,
+                                        CXTranslationUnit TU) {
+  CXComment Result;
+  Result.ASTNode = C;
+  Result.TranslationUnit = TU;
+  return Result;
+}
+
+static inline const comments::Comment *getASTNode(CXComment CXC) {
+  return static_cast<const comments::Comment *>(CXC.ASTNode);
+}
+
+template<typename T>
+static inline const T *getASTNodeAs(CXComment CXC) {
+  const comments::Comment *C = getASTNode(CXC);
+  if (!C)
+    return nullptr;
+
+  return dyn_cast<T>(C);
+}
+
+static inline ASTContext &getASTContext(CXComment CXC) {
+  return cxtu::getASTUnit(CXC.TranslationUnit)->getASTContext();
+}
+
+static inline comments::CommandTraits &getCommandTraits(CXComment CXC) {
+  return getASTContext(CXC).getCommentCommandTraits();
+}
+
+} // end namespace cxcomment
+} // end namespace clang
+
+#endif
+

--- a/libclang/CXCursor.h
+++ b/libclang/CXCursor.h
@@ -1,0 +1,299 @@
+//===- CXCursor.h - Routines for manipulating CXCursors -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines routines for manipulating CXCursors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CXCURSOR_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CXCURSOR_H
+
+#include "clang-c/Index.h"
+#include "clang/Basic/SourceLocation.h"
+#include "llvm/ADT/PointerUnion.h"
+#include <utility>
+
+namespace clang {
+
+class ASTContext;
+class ASTUnit;
+class Attr;
+class CXXBaseSpecifier;
+class Decl;
+class Expr;
+class FieldDecl;
+class InclusionDirective;
+class LabelStmt;
+class MacroDefinitionRecord;
+class MacroExpansion;
+class NamedDecl;
+class ObjCInterfaceDecl;
+class ObjCProtocolDecl;
+class OverloadedTemplateStorage;
+class OverloadExpr;
+class Stmt;
+class TemplateDecl;
+class TemplateName;
+class TypeDecl;
+class VarDecl;
+class IdentifierInfo;
+  
+namespace cxcursor {
+
+CXCursor getCursor(CXTranslationUnit, SourceLocation);
+  
+CXCursor MakeCXCursor(const clang::Attr *A, const clang::Decl *Parent,
+                      CXTranslationUnit TU);
+CXCursor MakeCXCursor(const clang::Decl *D, CXTranslationUnit TU,
+                      SourceRange RegionOfInterest = SourceRange(),
+                      bool FirstInDeclGroup = true);
+CXCursor MakeCXCursor(const clang::Stmt *S, const clang::Decl *Parent,
+                      CXTranslationUnit TU,
+                      SourceRange RegionOfInterest = SourceRange());
+CXCursor MakeCXCursorInvalid(CXCursorKind K, CXTranslationUnit TU = nullptr);
+
+/// \brief Create an Objective-C superclass reference at the given location.
+CXCursor MakeCursorObjCSuperClassRef(ObjCInterfaceDecl *Super, 
+                                     SourceLocation Loc, 
+                                     CXTranslationUnit TU);
+
+/// \brief Unpack an ObjCSuperClassRef cursor into the interface it references
+/// and optionally the location where the reference occurred.
+std::pair<const ObjCInterfaceDecl *, SourceLocation>
+  getCursorObjCSuperClassRef(CXCursor C);
+
+/// \brief Create an Objective-C protocol reference at the given location.
+CXCursor MakeCursorObjCProtocolRef(const ObjCProtocolDecl *Proto,
+                                   SourceLocation Loc, 
+                                   CXTranslationUnit TU);
+
+/// \brief Unpack an ObjCProtocolRef cursor into the protocol it references
+/// and optionally the location where the reference occurred.
+std::pair<const ObjCProtocolDecl *, SourceLocation>
+  getCursorObjCProtocolRef(CXCursor C);
+
+/// \brief Create an Objective-C class reference at the given location.
+CXCursor MakeCursorObjCClassRef(const ObjCInterfaceDecl *Class,
+                                SourceLocation Loc, 
+                                CXTranslationUnit TU);
+
+/// \brief Unpack an ObjCClassRef cursor into the class it references
+/// and optionally the location where the reference occurred.
+std::pair<const ObjCInterfaceDecl *, SourceLocation>
+  getCursorObjCClassRef(CXCursor C);
+
+/// \brief Create a type reference at the given location.
+CXCursor MakeCursorTypeRef(const TypeDecl *Type, SourceLocation Loc,
+                           CXTranslationUnit TU);
+                               
+/// \brief Unpack a TypeRef cursor into the class it references
+/// and optionally the location where the reference occurred.
+std::pair<const TypeDecl *, SourceLocation> getCursorTypeRef(CXCursor C);
+
+/// \brief Create a reference to a template at the given location.
+CXCursor MakeCursorTemplateRef(const TemplateDecl *Template, SourceLocation Loc,
+                               CXTranslationUnit TU);
+
+/// \brief Unpack a TemplateRef cursor into the template it references and
+/// the location where the reference occurred.
+std::pair<const TemplateDecl *, SourceLocation>
+  getCursorTemplateRef(CXCursor C);
+
+/// \brief Create a reference to a namespace or namespace alias at the given 
+/// location.
+CXCursor MakeCursorNamespaceRef(const NamedDecl *NS, SourceLocation Loc,
+                                CXTranslationUnit TU);
+
+/// \brief Unpack a NamespaceRef cursor into the namespace or namespace alias
+/// it references and the location where the reference occurred.
+std::pair<const NamedDecl *, SourceLocation> getCursorNamespaceRef(CXCursor C);
+
+/// \brief Create a reference to a variable at the given location.
+CXCursor MakeCursorVariableRef(const VarDecl *Var, SourceLocation Loc, 
+                               CXTranslationUnit TU);
+
+/// \brief Unpack a VariableRef cursor into the variable it references and the
+/// location where the where the reference occurred.
+std::pair<const VarDecl *, SourceLocation> getCursorVariableRef(CXCursor C);
+
+/// \brief Create a reference to a field at the given location.
+CXCursor MakeCursorMemberRef(const FieldDecl *Field, SourceLocation Loc, 
+                             CXTranslationUnit TU);
+  
+/// \brief Unpack a MemberRef cursor into the field it references and the 
+/// location where the reference occurred.
+std::pair<const FieldDecl *, SourceLocation> getCursorMemberRef(CXCursor C);
+
+/// \brief Create a CXX base specifier cursor.
+CXCursor MakeCursorCXXBaseSpecifier(const CXXBaseSpecifier *B,
+                                    CXTranslationUnit TU);
+
+/// \brief Unpack a CXXBaseSpecifier cursor into a CXXBaseSpecifier.
+const CXXBaseSpecifier *getCursorCXXBaseSpecifier(CXCursor C);
+
+/// \brief Create a preprocessing directive cursor.
+CXCursor MakePreprocessingDirectiveCursor(SourceRange Range,
+                                          CXTranslationUnit TU);
+
+/// \brief Unpack a given preprocessing directive to retrieve its source range.
+SourceRange getCursorPreprocessingDirective(CXCursor C);
+
+/// \brief Create a macro definition cursor.
+CXCursor MakeMacroDefinitionCursor(const MacroDefinitionRecord *,
+                                   CXTranslationUnit TU);
+
+/// \brief Unpack a given macro definition cursor to retrieve its
+/// source range.
+const MacroDefinitionRecord *getCursorMacroDefinition(CXCursor C);
+
+/// \brief Create a macro expansion cursor.
+CXCursor MakeMacroExpansionCursor(MacroExpansion *, CXTranslationUnit TU);
+
+/// \brief Create a "pseudo" macro expansion cursor, using a macro definition
+/// and a source location.
+CXCursor MakeMacroExpansionCursor(MacroDefinitionRecord *, SourceLocation Loc,
+                                  CXTranslationUnit TU);
+
+/// \brief Wraps a macro expansion cursor and provides a common interface
+/// for a normal macro expansion cursor or a "pseudo" one.
+///
+/// "Pseudo" macro expansion cursors (essentially a macro definition along with
+/// a source location) are created in special cases, for example they can be
+/// created for identifiers inside macro definitions, if these identifiers are
+/// macro names.
+class MacroExpansionCursor {
+  CXCursor C;
+
+  bool isPseudo() const { return C.data[1] != nullptr; }
+  const MacroDefinitionRecord *getAsMacroDefinition() const {
+    assert(isPseudo());
+    return static_cast<const MacroDefinitionRecord *>(C.data[0]);
+  }
+  const MacroExpansion *getAsMacroExpansion() const {
+    assert(!isPseudo());
+    return static_cast<const MacroExpansion *>(C.data[0]);
+  }
+  SourceLocation getPseudoLoc() const {
+    assert(isPseudo());
+    return SourceLocation::getFromPtrEncoding(C.data[1]);
+  }
+
+public:
+  MacroExpansionCursor(CXCursor C) : C(C) {
+    assert(C.kind == CXCursor_MacroExpansion);
+  }
+
+  const IdentifierInfo *getName() const;
+  const MacroDefinitionRecord *getDefinition() const;
+  SourceRange getSourceRange() const;
+};
+
+/// \brief Unpack a given macro expansion cursor to retrieve its info.
+static inline MacroExpansionCursor getCursorMacroExpansion(CXCursor C) {
+  return C;
+}
+
+/// \brief Create an inclusion directive cursor.
+CXCursor MakeInclusionDirectiveCursor(InclusionDirective *,
+                                      CXTranslationUnit TU);
+
+/// \brief Unpack a given inclusion directive cursor to retrieve its
+/// source range.
+const InclusionDirective *getCursorInclusionDirective(CXCursor C);
+
+/// \brief Create a label reference at the given location.
+CXCursor MakeCursorLabelRef(LabelStmt *Label, SourceLocation Loc,
+                            CXTranslationUnit TU);
+
+/// \brief Unpack a label reference into the label statement it refers to and
+/// the location of the reference.
+std::pair<const LabelStmt *, SourceLocation> getCursorLabelRef(CXCursor C);
+
+/// \brief Create a overloaded declaration reference cursor for an expression.
+CXCursor MakeCursorOverloadedDeclRef(const OverloadExpr *E,
+                                     CXTranslationUnit TU);
+
+/// \brief Create a overloaded declaration reference cursor for a declaration.
+CXCursor MakeCursorOverloadedDeclRef(const Decl *D, SourceLocation Location,
+                                     CXTranslationUnit TU);
+
+/// \brief Create a overloaded declaration reference cursor for a template name.
+CXCursor MakeCursorOverloadedDeclRef(TemplateName Template, 
+                                     SourceLocation Location,
+                                     CXTranslationUnit TU);
+
+/// \brief Internal storage for an overloaded declaration reference cursor;
+typedef llvm::PointerUnion3<const OverloadExpr *, const Decl *,
+                            OverloadedTemplateStorage *>
+  OverloadedDeclRefStorage;
+  
+/// \brief Unpack an overloaded declaration reference into an expression,
+/// declaration, or template name along with the source location.
+std::pair<OverloadedDeclRefStorage, SourceLocation>
+  getCursorOverloadedDeclRef(CXCursor C);
+  
+const Decl *getCursorDecl(CXCursor Cursor);
+const Expr *getCursorExpr(CXCursor Cursor);
+const Stmt *getCursorStmt(CXCursor Cursor);
+const Attr *getCursorAttr(CXCursor Cursor);
+const Decl *getCursorParentDecl(CXCursor Cursor);
+
+ASTContext &getCursorContext(CXCursor Cursor);
+ASTUnit *getCursorASTUnit(CXCursor Cursor);
+CXTranslationUnit getCursorTU(CXCursor Cursor);
+
+void getOverriddenCursors(CXCursor cursor,
+                          SmallVectorImpl<CXCursor> &overridden);
+  
+/// \brief Create an opaque  pool used for fast generation of overriden
+/// CXCursor arrays.
+void *createOverridenCXCursorsPool();
+
+/// \brief Dispose of the overriden CXCursors pool.
+void disposeOverridenCXCursorsPool(void *pool);
+  
+/// \brief Returns a index/location pair for a selector identifier if the cursor
+/// points to one.
+std::pair<int, SourceLocation> getSelectorIdentifierIndexAndLoc(CXCursor);
+static inline int getSelectorIdentifierIndex(CXCursor cursor) {
+  return getSelectorIdentifierIndexAndLoc(cursor).first;
+}
+static inline SourceLocation getSelectorIdentifierLoc(CXCursor cursor) {
+  return getSelectorIdentifierIndexAndLoc(cursor).second;
+}
+
+CXCursor getSelectorIdentifierCursor(int SelIdx, CXCursor cursor);
+
+static inline CXCursor getTypeRefedCallExprCursor(CXCursor cursor) {
+  CXCursor newCursor = cursor;
+  if (cursor.kind == CXCursor_CallExpr)
+    newCursor.xdata = 1;
+  return newCursor;
+}
+
+CXCursor getTypeRefCursor(CXCursor cursor);
+
+/// \brief Generate a USR for \arg D and put it in \arg Buf.
+/// \returns true if no USR was computed or the result should be ignored,
+/// false otherwise.
+bool getDeclCursorUSR(const Decl *D, SmallVectorImpl<char> &Buf);
+
+bool operator==(CXCursor X, CXCursor Y);
+  
+inline bool operator!=(CXCursor X, CXCursor Y) {
+  return !(X == Y);
+}
+
+/// \brief Return true if the cursor represents a declaration that is the
+/// first in a declaration group.
+bool isFirstInDeclGroup(CXCursor C);
+
+}} // end namespace: clang::cxcursor
+
+#endif

--- a/libclang/CXIndexDataConsumer.h
+++ b/libclang/CXIndexDataConsumer.h
@@ -1,0 +1,532 @@
+//===- CXIndexDataConsumer.h - Index data consumer for libclang--*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CXINDEXDATACONSUMER_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CXINDEXDATACONSUMER_H
+
+#include "CXCursor.h"
+#include "Index_Internal.h"
+#include "clang/Index/IndexDataConsumer.h"
+#include "clang/AST/DeclGroup.h"
+#include "clang/AST/DeclObjC.h"
+#include "llvm/ADT/DenseSet.h"
+
+namespace clang {
+  class FileEntry;
+  class MSPropertyDecl;
+  class ObjCPropertyDecl;
+  class ClassTemplateDecl;
+  class FunctionTemplateDecl;
+  class TypeAliasTemplateDecl;
+  class ClassTemplateSpecializationDecl;
+
+namespace cxindex {
+  class CXIndexDataConsumer;
+  class AttrListInfo;
+
+class ScratchAlloc {
+  CXIndexDataConsumer &IdxCtx;
+
+public:
+  explicit ScratchAlloc(CXIndexDataConsumer &indexCtx);
+  ScratchAlloc(const ScratchAlloc &SA);
+
+  ~ScratchAlloc();
+
+  const char *toCStr(StringRef Str);
+  const char *copyCStr(StringRef Str);
+
+  template <typename T>
+  T *allocate();
+};
+
+struct EntityInfo : public CXIdxEntityInfo {
+  const NamedDecl *Dcl;
+  CXIndexDataConsumer *IndexCtx;
+  IntrusiveRefCntPtr<AttrListInfo> AttrList;
+
+  EntityInfo() {
+    name = USR = nullptr;
+    attributes = nullptr;
+    numAttributes = 0;
+  }
+};
+
+struct ContainerInfo : public CXIdxContainerInfo {
+  const DeclContext *DC;
+  CXIndexDataConsumer *IndexCtx;
+};
+  
+struct DeclInfo : public CXIdxDeclInfo {
+  enum DInfoKind {
+    Info_Decl,
+
+    Info_ObjCContainer,
+      Info_ObjCInterface,
+      Info_ObjCProtocol,
+      Info_ObjCCategory,
+
+    Info_ObjCProperty,
+
+    Info_CXXClass
+  };
+  
+  DInfoKind Kind;
+
+  EntityInfo EntInfo;
+  ContainerInfo SemanticContainer;
+  ContainerInfo LexicalContainer;
+  ContainerInfo DeclAsContainer;
+
+  DeclInfo(bool isRedeclaration, bool isDefinition, bool isContainer)
+    : Kind(Info_Decl) {
+    this->isRedeclaration = isRedeclaration;
+    this->isDefinition = isDefinition;
+    this->isContainer = isContainer;
+    attributes = nullptr;
+    numAttributes = 0;
+    declAsContainer = semanticContainer = lexicalContainer = nullptr;
+    flags = 0;
+  }
+  DeclInfo(DInfoKind K,
+           bool isRedeclaration, bool isDefinition, bool isContainer)
+    : Kind(K) {
+    this->isRedeclaration = isRedeclaration;
+    this->isDefinition = isDefinition;
+    this->isContainer = isContainer;
+    attributes = nullptr;
+    numAttributes = 0;
+    declAsContainer = semanticContainer = lexicalContainer = nullptr;
+    flags = 0;
+  }
+};
+
+struct ObjCContainerDeclInfo : public DeclInfo {
+  CXIdxObjCContainerDeclInfo ObjCContDeclInfo;
+
+  ObjCContainerDeclInfo(bool isForwardRef,
+                        bool isRedeclaration,
+                        bool isImplementation)
+    : DeclInfo(Info_ObjCContainer, isRedeclaration,
+               /*isDefinition=*/!isForwardRef, /*isContainer=*/!isForwardRef) {
+    init(isForwardRef, isImplementation);
+  }
+  ObjCContainerDeclInfo(DInfoKind K,
+                        bool isForwardRef,
+                        bool isRedeclaration,
+                        bool isImplementation)
+    : DeclInfo(K, isRedeclaration, /*isDefinition=*/!isForwardRef,
+               /*isContainer=*/!isForwardRef) {
+    init(isForwardRef, isImplementation);
+  }
+
+  static bool classof(const DeclInfo *D) {
+    return Info_ObjCContainer <= D->Kind && D->Kind <= Info_ObjCCategory;
+  }
+
+private:
+  void init(bool isForwardRef, bool isImplementation) {
+    if (isForwardRef)
+      ObjCContDeclInfo.kind = CXIdxObjCContainer_ForwardRef;
+    else if (isImplementation)
+      ObjCContDeclInfo.kind = CXIdxObjCContainer_Implementation;
+    else
+      ObjCContDeclInfo.kind = CXIdxObjCContainer_Interface;
+  }
+};
+
+struct ObjCInterfaceDeclInfo : public ObjCContainerDeclInfo {
+  CXIdxObjCInterfaceDeclInfo ObjCInterDeclInfo;
+  CXIdxObjCProtocolRefListInfo ObjCProtoListInfo;
+
+  ObjCInterfaceDeclInfo(const ObjCInterfaceDecl *D)
+    : ObjCContainerDeclInfo(Info_ObjCInterface,
+                            /*isForwardRef=*/false,
+                            /*isRedeclaration=*/D->getPreviousDecl() != nullptr,
+                            /*isImplementation=*/false) { }
+
+  static bool classof(const DeclInfo *D) {
+    return D->Kind == Info_ObjCInterface;
+  }
+};
+
+struct ObjCProtocolDeclInfo : public ObjCContainerDeclInfo {
+  CXIdxObjCProtocolRefListInfo ObjCProtoRefListInfo;
+
+  ObjCProtocolDeclInfo(const ObjCProtocolDecl *D)
+    : ObjCContainerDeclInfo(Info_ObjCProtocol,
+                            /*isForwardRef=*/false,
+                            /*isRedeclaration=*/D->getPreviousDecl(),
+                            /*isImplementation=*/false) { }
+
+  static bool classof(const DeclInfo *D) {
+    return D->Kind == Info_ObjCProtocol;
+  }
+};
+
+struct ObjCCategoryDeclInfo : public ObjCContainerDeclInfo {
+  CXIdxObjCCategoryDeclInfo ObjCCatDeclInfo;
+  CXIdxObjCProtocolRefListInfo ObjCProtoListInfo;
+
+  explicit ObjCCategoryDeclInfo(bool isImplementation)
+    : ObjCContainerDeclInfo(Info_ObjCCategory,
+                            /*isForwardRef=*/false,
+                            /*isRedeclaration=*/isImplementation,
+                            /*isImplementation=*/isImplementation) { }
+
+  static bool classof(const DeclInfo *D) {
+    return D->Kind == Info_ObjCCategory;
+  }
+};
+
+struct ObjCPropertyDeclInfo : public DeclInfo {
+  CXIdxObjCPropertyDeclInfo ObjCPropDeclInfo;
+
+  ObjCPropertyDeclInfo()
+    : DeclInfo(Info_ObjCProperty,
+               /*isRedeclaration=*/false, /*isDefinition=*/false,
+               /*isContainer=*/false) { }
+
+  static bool classof(const DeclInfo *D) {
+    return D->Kind == Info_ObjCProperty;
+  }
+};
+
+struct CXXClassDeclInfo : public DeclInfo {
+  CXIdxCXXClassDeclInfo CXXClassInfo;
+
+  CXXClassDeclInfo(bool isRedeclaration, bool isDefinition)
+    : DeclInfo(Info_CXXClass, isRedeclaration, isDefinition, isDefinition) { }
+
+  static bool classof(const DeclInfo *D) {
+    return D->Kind == Info_CXXClass;
+  }
+};
+
+struct AttrInfo : public CXIdxAttrInfo {
+  const Attr *A;
+
+  AttrInfo(CXIdxAttrKind Kind, CXCursor C, CXIdxLoc Loc, const Attr *A) {
+    kind = Kind;
+    cursor = C;
+    loc = Loc;
+    this->A = A;
+  }
+};
+
+struct IBOutletCollectionInfo : public AttrInfo {
+  EntityInfo ClassInfo;
+  CXIdxIBOutletCollectionAttrInfo IBCollInfo;
+
+  IBOutletCollectionInfo(CXCursor C, CXIdxLoc Loc, const Attr *A) :
+    AttrInfo(CXIdxAttr_IBOutletCollection, C, Loc, A) {
+    assert(C.kind == CXCursor_IBOutletCollectionAttr);
+    IBCollInfo.objcClass = nullptr;
+  }
+
+  IBOutletCollectionInfo(const IBOutletCollectionInfo &other);
+
+  static bool classof(const AttrInfo *A) {
+    return A->kind == CXIdxAttr_IBOutletCollection;
+  }
+};
+
+class AttrListInfo {
+  ScratchAlloc SA;
+
+  SmallVector<AttrInfo, 2> Attrs;
+  SmallVector<IBOutletCollectionInfo, 2> IBCollAttrs;
+  SmallVector<CXIdxAttrInfo *, 2> CXAttrs;
+  unsigned ref_cnt;
+
+  AttrListInfo(const AttrListInfo &) = delete;
+  void operator=(const AttrListInfo &) = delete;
+public:
+  AttrListInfo(const Decl *D, CXIndexDataConsumer &IdxCtx);
+
+  static IntrusiveRefCntPtr<AttrListInfo> create(const Decl *D,
+                                                 CXIndexDataConsumer &IdxCtx);
+
+  const CXIdxAttrInfo *const *getAttrs() const {
+    if (CXAttrs.empty())
+      return nullptr;
+    return CXAttrs.data();
+  }
+  unsigned getNumAttrs() const { return (unsigned)CXAttrs.size(); }
+
+  /// \brief Retain/Release only useful when we allocate a AttrListInfo from the
+  /// BumpPtrAllocator, and not from the stack; so that we keep a pointer
+  // in the EntityInfo
+  void Retain() { ++ref_cnt; }
+  void Release() {
+    assert (ref_cnt > 0 && "Reference count is already zero.");
+    if (--ref_cnt == 0) {
+      // Memory is allocated from a BumpPtrAllocator, no need to delete it.
+      this->~AttrListInfo();
+    }
+  }
+};
+
+class CXIndexDataConsumer : public index::IndexDataConsumer {
+  ASTContext *Ctx;
+  CXClientData ClientData;
+  IndexerCallbacks &CB;
+  unsigned IndexOptions;
+  CXTranslationUnit CXTU;
+  
+  typedef llvm::DenseMap<const FileEntry *, CXIdxClientFile> FileMapTy;
+  typedef llvm::DenseMap<const DeclContext *, CXIdxClientContainer>
+    ContainerMapTy;
+  typedef llvm::DenseMap<const Decl *, CXIdxClientEntity> EntityMapTy;
+
+  FileMapTy FileMap;
+  ContainerMapTy ContainerMap;
+  EntityMapTy EntityMap;
+
+  typedef std::pair<const FileEntry *, const Decl *> RefFileOccurrence;
+  llvm::DenseSet<RefFileOccurrence> RefFileOccurrences;
+
+  llvm::BumpPtrAllocator StrScratch;
+  unsigned StrAdapterCount;
+  friend class ScratchAlloc;
+
+  struct ObjCProtocolListInfo {
+    SmallVector<CXIdxObjCProtocolRefInfo, 4> ProtInfos;
+    SmallVector<EntityInfo, 4> ProtEntities;
+    SmallVector<CXIdxObjCProtocolRefInfo *, 4> Prots;
+
+    CXIdxObjCProtocolRefListInfo getListInfo() const {
+      CXIdxObjCProtocolRefListInfo Info = { Prots.data(),
+                                            (unsigned)Prots.size() };
+      return Info;
+    }
+
+    ObjCProtocolListInfo(const ObjCProtocolList &ProtList,
+                         CXIndexDataConsumer &IdxCtx,
+                         ScratchAlloc &SA);
+  };
+
+  struct CXXBasesListInfo {
+    SmallVector<CXIdxBaseClassInfo, 4> BaseInfos;
+    SmallVector<EntityInfo, 4> BaseEntities;
+    SmallVector<CXIdxBaseClassInfo *, 4> CXBases;
+
+    const CXIdxBaseClassInfo *const *getBases() const {
+      return CXBases.data();
+    }
+    unsigned getNumBases() const { return (unsigned)CXBases.size(); }
+
+    CXXBasesListInfo(const CXXRecordDecl *D,
+                     CXIndexDataConsumer &IdxCtx, ScratchAlloc &SA);
+
+  private:
+    SourceLocation getBaseLoc(const CXXBaseSpecifier &Base) const;
+  };
+
+  friend class AttrListInfo;
+
+public:
+  CXIndexDataConsumer(CXClientData clientData, IndexerCallbacks &indexCallbacks,
+                  unsigned indexOptions, CXTranslationUnit cxTU)
+    : Ctx(nullptr), ClientData(clientData), CB(indexCallbacks),
+      IndexOptions(indexOptions), CXTU(cxTU),
+      StrScratch(), StrAdapterCount(0) { }
+
+  ASTContext &getASTContext() const { return *Ctx; }
+  CXTranslationUnit getCXTU() const { return CXTU; }
+
+  void setASTContext(ASTContext &ctx);
+  void setPreprocessor(std::shared_ptr<Preprocessor> PP) override;
+
+  bool shouldSuppressRefs() const {
+    return IndexOptions & CXIndexOpt_SuppressRedundantRefs;
+  }
+
+  bool shouldIndexFunctionLocalSymbols() const {
+    return IndexOptions & CXIndexOpt_IndexFunctionLocalSymbols;
+  }
+
+  bool shouldIndexImplicitTemplateInsts() const {
+    return IndexOptions & CXIndexOpt_IndexImplicitTemplateInstantiations;
+  }
+
+  static bool isFunctionLocalDecl(const Decl *D);
+
+  bool shouldAbort();
+
+  bool hasDiagnosticCallback() const { return CB.diagnostic; }
+
+  void enteredMainFile(const FileEntry *File);
+
+  void ppIncludedFile(SourceLocation hashLoc,
+                      StringRef filename, const FileEntry *File,
+                      bool isImport, bool isAngled, bool isModuleImport);
+
+  void importedModule(const ImportDecl *ImportD);
+  void importedPCH(const FileEntry *File);
+
+  void startedTranslationUnit();
+
+  void indexDecl(const Decl *D);
+
+  void indexTagDecl(const TagDecl *D);
+
+  void indexTypeSourceInfo(TypeSourceInfo *TInfo, const NamedDecl *Parent,
+                           const DeclContext *DC = nullptr);
+
+  void indexTypeLoc(TypeLoc TL, const NamedDecl *Parent,
+                    const DeclContext *DC = nullptr);
+
+  void indexNestedNameSpecifierLoc(NestedNameSpecifierLoc NNS,
+                                   const NamedDecl *Parent,
+                                   const DeclContext *DC = nullptr);
+
+  void indexDeclContext(const DeclContext *DC);
+  
+  void indexBody(const Stmt *S, const NamedDecl *Parent,
+                 const DeclContext *DC = nullptr);
+
+  void indexDiagnostics();
+
+  void handleDiagnosticSet(CXDiagnosticSet CXDiagSet);
+
+  bool handleFunction(const FunctionDecl *FD);
+
+  bool handleVar(const VarDecl *D);
+
+  bool handleField(const FieldDecl *D);
+
+  bool handleMSProperty(const MSPropertyDecl *D);
+
+  bool handleEnumerator(const EnumConstantDecl *D);
+
+  bool handleTagDecl(const TagDecl *D);
+  
+  bool handleTypedefName(const TypedefNameDecl *D);
+
+  bool handleObjCInterface(const ObjCInterfaceDecl *D);
+  bool handleObjCImplementation(const ObjCImplementationDecl *D);
+
+  bool handleObjCProtocol(const ObjCProtocolDecl *D);
+
+  bool handleObjCCategory(const ObjCCategoryDecl *D);
+  bool handleObjCCategoryImpl(const ObjCCategoryImplDecl *D);
+
+  bool handleObjCMethod(const ObjCMethodDecl *D, SourceLocation Loc);
+
+  bool handleSynthesizedObjCProperty(const ObjCPropertyImplDecl *D);
+  bool handleSynthesizedObjCMethod(const ObjCMethodDecl *D, SourceLocation Loc,
+                                   const DeclContext *LexicalDC);
+
+  bool handleObjCProperty(const ObjCPropertyDecl *D);
+
+  bool handleNamespace(const NamespaceDecl *D);
+
+  bool handleClassTemplate(const ClassTemplateDecl *D);
+  bool handleFunctionTemplate(const FunctionTemplateDecl *D);
+  bool handleTypeAliasTemplate(const TypeAliasTemplateDecl *D);
+
+  bool handleReference(const NamedDecl *D, SourceLocation Loc, CXCursor Cursor,
+                       const NamedDecl *Parent,
+                       const DeclContext *DC,
+                       const Expr *E = nullptr,
+                       CXIdxEntityRefKind Kind = CXIdxEntityRef_Direct);
+
+  bool handleReference(const NamedDecl *D, SourceLocation Loc,
+                       const NamedDecl *Parent,
+                       const DeclContext *DC,
+                       const Expr *E = nullptr,
+                       CXIdxEntityRefKind Kind = CXIdxEntityRef_Direct);
+
+  bool isNotFromSourceFile(SourceLocation Loc) const;
+
+  void indexTopLevelDecl(const Decl *D);
+  void indexDeclGroupRef(DeclGroupRef DG);
+
+  void translateLoc(SourceLocation Loc, CXIdxClientFile *indexFile, CXFile *file,
+                    unsigned *line, unsigned *column, unsigned *offset);
+
+  CXIdxClientContainer getClientContainerForDC(const DeclContext *DC) const;
+  void addContainerInMap(const DeclContext *DC, CXIdxClientContainer container);
+
+  CXIdxClientEntity getClientEntity(const Decl *D) const;
+  void setClientEntity(const Decl *D, CXIdxClientEntity client);
+
+  static bool isTemplateImplicitInstantiation(const Decl *D);
+
+private:
+  bool handleDeclOccurence(const Decl *D, index::SymbolRoleSet Roles,
+                           ArrayRef<index::SymbolRelation> Relations,
+                           FileID FID, unsigned Offset,
+                           ASTNodeInfo ASTNode) override;
+
+  bool handleModuleOccurence(const ImportDecl *ImportD,
+                             index::SymbolRoleSet Roles,
+                             FileID FID, unsigned Offset) override;
+
+  void finish() override;
+
+  bool handleDecl(const NamedDecl *D,
+                  SourceLocation Loc, CXCursor Cursor,
+                  DeclInfo &DInfo,
+                  const DeclContext *LexicalDC = nullptr,
+                  const DeclContext *SemaDC = nullptr);
+
+  bool handleObjCContainer(const ObjCContainerDecl *D,
+                           SourceLocation Loc, CXCursor Cursor,
+                           ObjCContainerDeclInfo &ContDInfo);
+
+  bool handleCXXRecordDecl(const CXXRecordDecl *RD, const NamedDecl *OrigD);
+
+  bool markEntityOccurrenceInFile(const NamedDecl *D, SourceLocation Loc);
+
+  const NamedDecl *getEntityDecl(const NamedDecl *D) const;
+
+  const DeclContext *getEntityContainer(const Decl *D) const;
+
+  CXIdxClientFile getIndexFile(const FileEntry *File);
+  
+  CXIdxLoc getIndexLoc(SourceLocation Loc) const;
+
+  void getEntityInfo(const NamedDecl *D,
+                     EntityInfo &EntityInfo,
+                     ScratchAlloc &SA);
+
+  void getContainerInfo(const DeclContext *DC, ContainerInfo &ContInfo);
+
+  CXCursor getCursor(const Decl *D) {
+    return cxcursor::MakeCXCursor(D, CXTU);
+  }
+
+  CXCursor getRefCursor(const NamedDecl *D, SourceLocation Loc);
+
+  static bool shouldIgnoreIfImplicit(const Decl *D);
+};
+
+inline ScratchAlloc::ScratchAlloc(CXIndexDataConsumer &idxCtx) : IdxCtx(idxCtx) {
+  ++IdxCtx.StrAdapterCount;
+}
+inline ScratchAlloc::ScratchAlloc(const ScratchAlloc &SA) : IdxCtx(SA.IdxCtx) {
+  ++IdxCtx.StrAdapterCount;
+}
+
+inline ScratchAlloc::~ScratchAlloc() {
+  --IdxCtx.StrAdapterCount;
+  if (IdxCtx.StrAdapterCount == 0)
+    IdxCtx.StrScratch.Reset();
+}
+
+template <typename T>
+inline T *ScratchAlloc::allocate() {
+  return IdxCtx.StrScratch.Allocate<T>();
+}
+
+}} // end clang::cxindex
+
+#endif

--- a/libclang/CXLoadedDiagnostic.h
+++ b/libclang/CXLoadedDiagnostic.h
@@ -1,0 +1,93 @@
+/*===-- CXLoadedDiagnostic.h - Handling of persisent diags ------*- C++ -*-===*\
+|*                                                                            *|
+|*                     The LLVM Compiler Infrastructure                       *|
+|*                                                                            *|
+|* This file is distributed under the University of Illinois Open Source      *|
+|* License. See LICENSE.TXT for details.                                      *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* Implements handling of persisent diagnostics.                              *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CXLOADEDDIAGNOSTIC_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CXLOADEDDIAGNOSTIC_H
+
+#include "CIndexDiagnostic.h"
+#include "llvm/ADT/StringRef.h"
+#include "clang/Basic/LLVM.h"
+#include <vector>
+
+namespace clang {
+class CXLoadedDiagnostic : public CXDiagnosticImpl {
+public:
+  CXLoadedDiagnostic() : CXDiagnosticImpl(LoadedDiagnosticKind),
+    severity(0), category(0) {}
+
+  ~CXLoadedDiagnostic() override;
+
+  /// \brief Return the severity of the diagnostic.
+  CXDiagnosticSeverity getSeverity() const override;
+
+  /// \brief Return the location of the diagnostic.
+  CXSourceLocation getLocation() const override;
+
+  /// \brief Return the spelling of the diagnostic.
+  CXString getSpelling() const override;
+
+  /// \brief Return the text for the diagnostic option.
+  CXString getDiagnosticOption(CXString *Disable) const override;
+
+  /// \brief Return the category of the diagnostic.
+  unsigned getCategory() const override;
+
+  /// \brief Return the category string of the diagnostic.
+  CXString getCategoryText() const override;
+
+  /// \brief Return the number of source ranges for the diagnostic.
+  unsigned getNumRanges() const override;
+
+  /// \brief Return the source ranges for the diagnostic.
+  CXSourceRange getRange(unsigned Range) const override;
+
+  /// \brief Return the number of FixIts.
+  unsigned getNumFixIts() const override;
+
+  /// \brief Return the FixIt information (source range and inserted text).
+  CXString getFixIt(unsigned FixIt,
+                    CXSourceRange *ReplacementRange) const override;
+
+  static bool classof(const CXDiagnosticImpl *D) {
+    return D->getKind() == LoadedDiagnosticKind;
+  }
+  
+  /// \brief Decode the CXSourceLocation into file, line, column, and offset.
+  static void decodeLocation(CXSourceLocation location,
+                             CXFile *file,
+                             unsigned *line,
+                             unsigned *column,
+                             unsigned *offset);
+
+  struct Location {
+    CXFile file;
+    unsigned line;
+    unsigned column;
+    unsigned offset;
+    
+    Location() : line(0), column(0), offset(0) {}    
+  };
+  
+  Location DiagLoc;
+
+  std::vector<CXSourceRange> Ranges;
+  std::vector<std::pair<CXSourceRange, const char *> > FixIts;
+  const char *Spelling;
+  llvm::StringRef DiagOption;
+  llvm::StringRef CategoryText;
+  unsigned severity;
+  unsigned category;
+};
+}
+
+#endif

--- a/libclang/CXSourceLocation.h
+++ b/libclang/CXSourceLocation.h
@@ -1,0 +1,78 @@
+//===- CXSourceLocation.h - CXSourceLocations Utilities ---------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines routines for manipulating CXSourceLocations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CXSOURCELOCATION_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CXSOURCELOCATION_H
+
+#include "clang-c/Index.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/Basic/LangOptions.h"
+#include "clang/Basic/SourceLocation.h"
+
+namespace clang {
+
+class SourceManager;
+
+namespace cxloc {
+
+/// \brief Translate a Clang source location into a CIndex source location.
+static inline CXSourceLocation 
+translateSourceLocation(const SourceManager &SM, const LangOptions &LangOpts,
+                        SourceLocation Loc) {
+  if (Loc.isInvalid())
+    clang_getNullLocation();
+
+  CXSourceLocation Result = { { &SM, &LangOpts, },
+                              Loc.getRawEncoding() };
+  return Result;
+}
+  
+/// \brief Translate a Clang source location into a CIndex source location.
+static inline CXSourceLocation translateSourceLocation(ASTContext &Context,
+                                                       SourceLocation Loc) {
+  return translateSourceLocation(Context.getSourceManager(),
+                                 Context.getLangOpts(),
+                                 Loc);
+}
+
+/// \brief Translate a Clang source range into a CIndex source range.
+///
+/// Clang internally represents ranges where the end location points to the
+/// start of the token at the end. However, for external clients it is more
+/// useful to have a CXSourceRange be a proper half-open interval. This routine
+/// does the appropriate translation.
+CXSourceRange translateSourceRange(const SourceManager &SM, 
+                                   const LangOptions &LangOpts,
+                                   const CharSourceRange &R);
+  
+/// \brief Translate a Clang source range into a CIndex source range.
+static inline CXSourceRange translateSourceRange(ASTContext &Context,
+                                                 SourceRange R) {
+  return translateSourceRange(Context.getSourceManager(),
+                              Context.getLangOpts(),
+                              CharSourceRange::getTokenRange(R));
+}
+
+static inline SourceLocation translateSourceLocation(CXSourceLocation L) {
+  return SourceLocation::getFromRawEncoding(L.int_data);
+}
+
+static inline SourceRange translateCXSourceRange(CXSourceRange R) {
+  return SourceRange(SourceLocation::getFromRawEncoding(R.begin_int_data),
+                     SourceLocation::getFromRawEncoding(R.end_int_data));
+}
+
+
+}} // end namespace: clang::cxloc
+
+#endif

--- a/libclang/CXString.h
+++ b/libclang/CXString.h
@@ -1,0 +1,109 @@
+//===- CXString.h - Routines for manipulating CXStrings -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines routines for manipulating CXStrings.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CXSTRING_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CXSTRING_H
+
+#include "clang-c/Index.h"
+#include "clang/Basic/LLVM.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
+#include <string>
+#include <vector>
+
+namespace clang {
+namespace cxstring {
+
+struct CXStringBuf;
+
+/// \brief Create a CXString object for an empty "" string.
+CXString createEmpty();
+
+/// \brief Create a CXString object for an NULL string.
+///
+/// A NULL string should be used as an "invalid" value in case of errors.
+CXString createNull();
+
+/// \brief Create a CXString object from a nul-terminated C string.  New
+/// CXString may contain a pointer to \p String.
+///
+/// \p String should not be changed by the caller afterwards.
+CXString createRef(const char *String);
+
+/// \brief Create a CXString object from a nul-terminated C string.  New
+/// CXString will contain a copy of \p String.
+///
+/// \p String can be changed or freed by the caller.
+CXString createDup(const char *String);
+
+/// \brief Create a CXString object from a StringRef.  New CXString may
+/// contain a pointer to the undrelying data of \p String.
+///
+/// \p String should not be changed by the caller afterwards.
+CXString createRef(StringRef String);
+
+/// \brief Create a CXString object from a StringRef.  New CXString will
+/// contain a copy of \p String.
+///
+/// \p String can be changed or freed by the caller.
+CXString createDup(StringRef String);
+
+// Usually std::string is intended to be used as backing storage for CXString.
+// In this case, call \c createRef(String.c_str()).
+//
+// If you need to make a copy, call \c createDup(StringRef(String)).
+CXString createRef(std::string String) = delete;
+
+/// \brief Create a CXString object that is backed by a string buffer.
+CXString createCXString(CXStringBuf *buf);
+
+CXStringSet *createSet(const std::vector<std::string> &Strings);
+
+/// \brief A string pool used for fast allocation/deallocation of strings.
+class CXStringPool {
+public:
+  ~CXStringPool();
+
+  CXStringBuf *getCXStringBuf(CXTranslationUnit TU);
+
+private:
+  std::vector<CXStringBuf *> Pool;
+
+  friend struct CXStringBuf;
+};
+
+struct CXStringBuf {
+  SmallString<128> Data;
+  CXTranslationUnit TU;
+
+  CXStringBuf(CXTranslationUnit TU) : TU(TU) {}
+
+  /// \brief Return this buffer to the pool.
+  void dispose();
+};
+
+CXStringBuf *getCXStringBuf(CXTranslationUnit TU);
+
+/// \brief Returns true if the CXString data is managed by a pool.
+bool isManagedByPool(CXString str);
+
+}
+
+static inline StringRef getContents(const CXUnsavedFile &UF) {
+  return StringRef(UF.Contents, UF.Length);
+}
+}
+
+#endif
+

--- a/libclang/CXTranslationUnit.h
+++ b/libclang/CXTranslationUnit.h
@@ -1,0 +1,90 @@
+//===- CXTranslationUnit.h - Routines for manipulating CXTranslationUnits -===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines routines for manipulating CXTranslationUnits.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CXTRANSLATIONUNIT_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CXTRANSLATIONUNIT_H
+
+#include "CLog.h"
+#include "CXString.h"
+#include "clang-c/Index.h"
+
+namespace clang {
+  class ASTUnit;
+  class CIndexer;
+namespace index {
+class CommentToXMLConverter;
+} // namespace index
+} // namespace clang
+
+struct CXTranslationUnitImpl {
+  clang::CIndexer *CIdx;
+  clang::ASTUnit *TheASTUnit;
+  clang::cxstring::CXStringPool *StringPool;
+  void *Diagnostics;
+  void *OverridenCursorsPool;
+  clang::index::CommentToXMLConverter *CommentToXML;
+  unsigned ParsingOptions;
+  std::vector<std::string> Arguments;
+};
+
+struct CXTargetInfoImpl {
+  CXTranslationUnit TranslationUnit;
+};
+
+namespace clang {
+namespace cxtu {
+
+CXTranslationUnitImpl *MakeCXTranslationUnit(CIndexer *CIdx,
+                                             std::unique_ptr<ASTUnit> AU);
+
+static inline ASTUnit *getASTUnit(CXTranslationUnit TU) {
+  if (!TU)
+    return nullptr;
+  return TU->TheASTUnit;
+}
+
+/// \returns true if the ASTUnit has a diagnostic about the AST file being
+/// corrupted.
+bool isASTReadError(ASTUnit *AU);
+
+static inline bool isNotUsableTU(CXTranslationUnit TU) {
+  return !TU;
+}
+
+#define LOG_BAD_TU(TU)                                  \
+    do {                                                \
+      LOG_FUNC_SECTION {                                \
+        *Log << "called with a bad TU: " << TU;         \
+      }                                                 \
+    } while(false)
+
+class CXTUOwner {
+  CXTranslationUnitImpl *TU;
+  
+public:
+  CXTUOwner(CXTranslationUnitImpl *tu) : TU(tu) { }
+  ~CXTUOwner();
+
+  CXTranslationUnitImpl *getTU() const { return TU; }
+
+  CXTranslationUnitImpl *takeTU() {
+    CXTranslationUnitImpl *retTU = TU;
+    TU = nullptr;
+    return retTU;
+  }
+};
+
+
+}} // end namespace clang::cxtu
+
+#endif

--- a/libclang/CXType.h
+++ b/libclang/CXType.h
@@ -1,0 +1,29 @@
+//===- CXTypes.h - Routines for manipulating CXTypes ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines routines for manipulating CXCursors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CXTYPE_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CXTYPE_H
+
+#include "clang-c/Index.h"
+#include "clang/AST/Type.h"
+
+namespace clang {
+  
+class ASTUnit;
+  
+namespace cxtype {
+  
+CXType MakeCXType(QualType T, CXTranslationUnit TU);
+  
+}} // end namespace clang::cxtype
+#endif

--- a/libclang/CursorVisitor.h
+++ b/libclang/CursorVisitor.h
@@ -1,0 +1,278 @@
+//===- CursorVisitor.h - CursorVisitor interface ----------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CURSORVISITOR_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CURSORVISITOR_H
+
+#include "CXCursor.h"
+#include "CXTranslationUnit.h"
+#include "Index_Internal.h"
+#include "clang/AST/DeclVisitor.h"
+#include "clang/AST/TypeLocVisitor.h"
+
+namespace clang {
+  class PreprocessingRecord;
+  class ASTUnit;
+
+namespace cxcursor {
+
+class VisitorJob {
+public:
+  enum Kind { DeclVisitKind, StmtVisitKind, MemberExprPartsKind,
+              TypeLocVisitKind, OverloadExprPartsKind,
+              DeclRefExprPartsKind, LabelRefVisitKind,
+              ExplicitTemplateArgsVisitKind,
+              NestedNameSpecifierLocVisitKind,
+              DeclarationNameInfoVisitKind,
+              MemberRefVisitKind, SizeOfPackExprPartsKind,
+              LambdaExprPartsKind, PostChildrenVisitKind };
+protected:
+  const void *data[3];
+  CXCursor parent;
+  Kind K;
+  VisitorJob(CXCursor C, Kind k, const void *d1, const void *d2 = nullptr,
+             const void *d3 = nullptr)
+    : parent(C), K(k) {
+    data[0] = d1;
+    data[1] = d2;
+    data[2] = d3;
+  }
+public:
+  Kind getKind() const { return K; }
+  const CXCursor &getParent() const { return parent; }
+};
+  
+typedef SmallVector<VisitorJob, 10> VisitorWorkList;
+
+// Cursor visitor.
+class CursorVisitor : public DeclVisitor<CursorVisitor, bool>,
+                      public TypeLocVisitor<CursorVisitor, bool>
+{
+public:
+  /// \brief Callback called after child nodes of a cursor have been visited.
+  /// Return true to break visitation or false to continue.
+  typedef bool (*PostChildrenVisitorTy)(CXCursor cursor,
+                                        CXClientData client_data);
+
+private:
+  /// \brief The translation unit we are traversing.
+  CXTranslationUnit TU;
+  ASTUnit *AU;
+
+  /// \brief The parent cursor whose children we are traversing.
+  CXCursor Parent;
+
+  /// \brief The declaration that serves at the parent of any statement or
+  /// expression nodes.
+  const Decl *StmtParent;
+
+  /// \brief The visitor function.
+  CXCursorVisitor Visitor;
+
+  PostChildrenVisitorTy PostChildrenVisitor;
+
+  /// \brief The opaque client data, to be passed along to the visitor.
+  CXClientData ClientData;
+
+  /// \brief Whether we should visit the preprocessing record entries last, 
+  /// after visiting other declarations.
+  bool VisitPreprocessorLast;
+
+  /// \brief Whether we should visit declarations or preprocessing record
+  /// entries that are #included inside the \arg RegionOfInterest.
+  bool VisitIncludedEntities;
+  
+  /// \brief When valid, a source range to which the cursor should restrict
+  /// its search.
+  SourceRange RegionOfInterest;
+
+  /// \brief Whether we should only visit declarations and not preprocessing
+  /// record entries.
+  bool VisitDeclsOnly;
+
+  // FIXME: Eventually remove.  This part of a hack to support proper
+  // iteration over all Decls contained lexically within an ObjC container.
+  DeclContext::decl_iterator *DI_current;
+  DeclContext::decl_iterator DE_current;
+  SmallVectorImpl<Decl *>::iterator *FileDI_current;
+  SmallVectorImpl<Decl *>::iterator FileDE_current;
+
+  // Cache of pre-allocated worklists for data-recursion walk of Stmts.
+  SmallVector<VisitorWorkList*, 5> WorkListFreeList;
+  SmallVector<VisitorWorkList*, 5> WorkListCache;
+
+  using DeclVisitor<CursorVisitor, bool>::Visit;
+  using TypeLocVisitor<CursorVisitor, bool>::Visit;
+
+  /// \brief Determine whether this particular source range comes before, comes
+  /// after, or overlaps the region of interest.
+  ///
+  /// \param R a half-open source range retrieved from the abstract syntax tree.
+  RangeComparisonResult CompareRegionOfInterest(SourceRange R);
+
+  bool visitDeclsFromFileRegion(FileID File, unsigned Offset, unsigned Length);
+
+  class SetParentRAII {
+    CXCursor &Parent;
+    const Decl *&StmtParent;
+    CXCursor OldParent;
+
+  public:
+    SetParentRAII(CXCursor &Parent, const Decl *&StmtParent,
+                  CXCursor NewParent)
+      : Parent(Parent), StmtParent(StmtParent), OldParent(Parent)
+    {
+      Parent = NewParent;
+      if (clang_isDeclaration(Parent.kind))
+        StmtParent = getCursorDecl(Parent);
+    }
+
+    ~SetParentRAII() {
+      Parent = OldParent;
+      if (clang_isDeclaration(Parent.kind))
+        StmtParent = getCursorDecl(Parent);
+    }
+  };
+
+public:
+  CursorVisitor(CXTranslationUnit TU, CXCursorVisitor Visitor,
+                CXClientData ClientData,
+                bool VisitPreprocessorLast,
+                bool VisitIncludedPreprocessingEntries = false,
+                SourceRange RegionOfInterest = SourceRange(),
+                bool VisitDeclsOnly = false,
+                PostChildrenVisitorTy PostChildrenVisitor = nullptr)
+    : TU(TU), AU(cxtu::getASTUnit(TU)),
+      Visitor(Visitor), PostChildrenVisitor(PostChildrenVisitor),
+      ClientData(ClientData),
+      VisitPreprocessorLast(VisitPreprocessorLast),
+      VisitIncludedEntities(VisitIncludedPreprocessingEntries),
+      RegionOfInterest(RegionOfInterest),
+      VisitDeclsOnly(VisitDeclsOnly),
+      DI_current(nullptr), FileDI_current(nullptr)
+  {
+    Parent.kind = CXCursor_NoDeclFound;
+    Parent.data[0] = nullptr;
+    Parent.data[1] = nullptr;
+    Parent.data[2] = nullptr;
+    StmtParent = nullptr;
+  }
+
+  ~CursorVisitor() {
+    // Free the pre-allocated worklists for data-recursion.
+    for (SmallVectorImpl<VisitorWorkList*>::iterator
+          I = WorkListCache.begin(), E = WorkListCache.end(); I != E; ++I) {
+      delete *I;
+    }
+  }
+
+  ASTUnit *getASTUnit() const { return AU; }
+  CXTranslationUnit getTU() const { return TU; }
+
+  bool Visit(CXCursor Cursor, bool CheckedRegionOfInterest = false);
+
+  /// \brief Visit declarations and preprocessed entities for the file region
+  /// designated by \see RegionOfInterest.
+  bool visitFileRegion();
+  
+  bool visitPreprocessedEntitiesInRegion();
+
+  bool shouldVisitIncludedEntities() const {
+    return VisitIncludedEntities;
+  }
+
+  template<typename InputIterator>
+  bool visitPreprocessedEntities(InputIterator First, InputIterator Last,
+                                 PreprocessingRecord &PPRec,
+                                 FileID FID = FileID());
+
+  bool VisitChildren(CXCursor Parent);
+
+  // Declaration visitors
+  bool VisitTypeAliasTemplateDecl(TypeAliasTemplateDecl *D);
+  bool VisitTypeAliasDecl(TypeAliasDecl *D);
+  bool VisitAttributes(Decl *D);
+  bool VisitBlockDecl(BlockDecl *B);
+  bool VisitCXXRecordDecl(CXXRecordDecl *D);
+  Optional<bool> shouldVisitCursor(CXCursor C);
+  bool VisitDeclContext(DeclContext *DC);
+  bool VisitTranslationUnitDecl(TranslationUnitDecl *D);
+  bool VisitTypedefDecl(TypedefDecl *D);
+  bool VisitTagDecl(TagDecl *D);
+  bool VisitClassTemplateSpecializationDecl(ClassTemplateSpecializationDecl *D);
+  bool VisitClassTemplatePartialSpecializationDecl(
+                                     ClassTemplatePartialSpecializationDecl *D);
+  bool VisitTemplateTypeParmDecl(TemplateTypeParmDecl *D);
+  bool VisitEnumConstantDecl(EnumConstantDecl *D);
+  bool VisitDeclaratorDecl(DeclaratorDecl *DD);
+  bool VisitFunctionDecl(FunctionDecl *ND);
+  bool VisitFieldDecl(FieldDecl *D);
+  bool VisitVarDecl(VarDecl *);
+  bool VisitNonTypeTemplateParmDecl(NonTypeTemplateParmDecl *D);
+  bool VisitFunctionTemplateDecl(FunctionTemplateDecl *D);
+  bool VisitClassTemplateDecl(ClassTemplateDecl *D);
+  bool VisitTemplateTemplateParmDecl(TemplateTemplateParmDecl *D);
+  bool VisitObjCTypeParamDecl(ObjCTypeParamDecl *D);
+  bool VisitObjCMethodDecl(ObjCMethodDecl *ND);
+  bool VisitObjCContainerDecl(ObjCContainerDecl *D);
+  bool VisitObjCCategoryDecl(ObjCCategoryDecl *ND);
+  bool VisitObjCProtocolDecl(ObjCProtocolDecl *PID);
+  bool VisitObjCPropertyDecl(ObjCPropertyDecl *PD);
+  bool VisitObjCTypeParamList(ObjCTypeParamList *typeParamList);
+  bool VisitObjCInterfaceDecl(ObjCInterfaceDecl *D);
+  bool VisitObjCImplDecl(ObjCImplDecl *D);
+  bool VisitObjCCategoryImplDecl(ObjCCategoryImplDecl *D);
+  bool VisitObjCImplementationDecl(ObjCImplementationDecl *D);
+  // FIXME: ObjCCompatibleAliasDecl requires aliased-class locations.
+  bool VisitObjCPropertyImplDecl(ObjCPropertyImplDecl *PD);
+  bool VisitLinkageSpecDecl(LinkageSpecDecl *D);
+  bool VisitNamespaceDecl(NamespaceDecl *D);
+  bool VisitNamespaceAliasDecl(NamespaceAliasDecl *D);
+  bool VisitUsingDirectiveDecl(UsingDirectiveDecl *D);
+  bool VisitUsingDecl(UsingDecl *D);
+  bool VisitUnresolvedUsingValueDecl(UnresolvedUsingValueDecl *D);
+  bool VisitUnresolvedUsingTypenameDecl(UnresolvedUsingTypenameDecl *D);
+  bool VisitStaticAssertDecl(StaticAssertDecl *D);
+  bool VisitFriendDecl(FriendDecl *D);
+
+  // Name visitor
+  bool VisitDeclarationNameInfo(DeclarationNameInfo Name);
+  bool VisitNestedNameSpecifier(NestedNameSpecifier *NNS, SourceRange Range);
+  bool VisitNestedNameSpecifierLoc(NestedNameSpecifierLoc NNS);
+  
+  // Template visitors
+  bool VisitTemplateParameters(const TemplateParameterList *Params);
+  bool VisitTemplateName(TemplateName Name, SourceLocation Loc);
+  bool VisitTemplateArgumentLoc(const TemplateArgumentLoc &TAL);
+  
+  // Type visitors
+#define ABSTRACT_TYPELOC(CLASS, PARENT)
+#define TYPELOC(CLASS, PARENT) \
+  bool Visit##CLASS##TypeLoc(CLASS##TypeLoc TyLoc);
+#include "clang/AST/TypeLocNodes.def"
+
+  bool VisitTagTypeLoc(TagTypeLoc TL);
+  bool VisitArrayTypeLoc(ArrayTypeLoc TL);
+  bool VisitFunctionTypeLoc(FunctionTypeLoc TL, bool SkipResultType = false);
+
+  // Data-recursive visitor functions.
+  bool IsInRegionOfInterest(CXCursor C);
+  bool RunVisitorWorkList(VisitorWorkList &WL);
+  void EnqueueWorkList(VisitorWorkList &WL, const Stmt *S);
+  LLVM_ATTRIBUTE_NOINLINE bool Visit(const Stmt *S);
+
+private:
+  Optional<bool> handleDeclForVisitation(const Decl *D);
+};
+
+}
+}
+
+#endif
+

--- a/libclang/Index_Internal.h
+++ b/libclang/Index_Internal.h
@@ -1,0 +1,55 @@
+//===- CXString.h - Routines for manipulating CXStrings -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines routines for manipulating CXStrings.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_INDEX_INTERNAL_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_INDEX_INTERNAL_H
+
+#include "clang-c/Index.h"
+
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#if __has_feature(blocks)
+
+#define INVOKE_BLOCK2(block, arg1, arg2) block(arg1, arg2)
+
+#else
+// If we are compiled with a compiler that doesn't have native blocks support,
+// define and call the block manually. 
+
+#define INVOKE_BLOCK2(block, arg1, arg2) block->invoke(block, arg1, arg2)
+
+typedef struct _CXCursorAndRangeVisitorBlock {
+  void *isa;
+  int flags;
+  int reserved;
+  enum CXVisitorResult (*invoke)(_CXCursorAndRangeVisitorBlock *,
+                                 CXCursor, CXSourceRange);
+} *CXCursorAndRangeVisitorBlock;
+
+#endif // !__has_feature(blocks)
+
+/// \brief The result of comparing two source ranges.
+enum RangeComparisonResult {
+  /// \brief Either the ranges overlap or one of the ranges is invalid.
+  RangeOverlap,
+
+  /// \brief The first range ends before the second range starts.
+  RangeBefore,
+
+  /// \brief The first range starts after the second range ends.
+  RangeAfter
+};
+
+#endif

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -544,6 +544,18 @@ struct FileContentsWithOffsets {
   optional<std::string> ContentsInRange(Range range) const;
 };
 
+struct NamespaceHelper {
+  std::unordered_map<ClangCursor, std::string>
+      container_cursor_to_qualified_name;
+
+  void RegisterQualifiedName(std::string usr,
+                             const CXIdxContainerInfo* container,
+                             std::string qualified_name) {}
+
+  std::string QualifiedName(const CXIdxContainerInfo* container,
+                            std::string unqualified_name);
+};
+
 // |import_file| is the cc file which is what gets passed to clang.
 // |desired_index_file| is the (h or cc) file which has actually changed.
 // |dependencies| are the existing dependencies of |import_file| if this is a

--- a/src/type_printer.cc
+++ b/src/type_printer.cc
@@ -1,0 +1,167 @@
+#include "type_printer.h"
+#include <string>
+#include "loguru.hpp"
+
+#if USE_CLANG_CXX
+# include "CXTranslationUnit.h"
+# include "clang/AST/Type.h"
+# include "clang/AST/PrettyPrinter.h"
+# include "clang/Frontend/ASTUnit.h"
+# include "llvm/ADT/SmallString.h"
+# include "llvm/Support/raw_ostream.h"
+
+using namespace clang;
+
+// Extracted from clang/tools/libclang/CXType.cpp
+static inline QualType GetQualType(CXType CT) {
+  return QualType::getFromOpaquePtr(CT.data[0]);
+}
+
+static inline CXTranslationUnit GetTU(CXType CT) {
+  return static_cast<CXTranslationUnit>(CT.data[1]);
+}
+#endif
+
+namespace {
+
+// TODO int(*sig(int(*)(int)))(int); is incorrect
+// int(A::*(*y())(int))() is correct
+int GetNameInsertingPosition(const std::string& type_desc) {
+  int ret = -1;
+
+  // Scan the function type backwards.
+  // First pass: find the position of the closing bracket in the type.
+  for (int balance = 0, i = int(type_desc.size()); i--;) {
+    if (type_desc[i] == ')')
+      balance++;
+    // Balanced paren pair that may appear before the paren enclosing
+    // function parameters, see clang/lib/AST/TypePrinter.cpp
+    else if (type_desc[i] == '(' && --balance == 0 &&
+             !((i >= 5 && !type_desc.compare(i - 5, 5, "throw")) ||
+               (i >= 6 && !type_desc.compare(i - 6, 6, "typeof")) ||
+               (i >= 7 && !type_desc.compare(i - 7, 7, "_Atomic")) ||
+               (i >= 7 && !type_desc.compare(i - 7, 7, "typeof ")) ||
+               (i >= 8 && !type_desc.compare(i - 8, 8, "decltype")) ||
+               (i >= 8 && !type_desc.compare(i - 8, 8, "noexcept")) ||
+               (i >= 13 && !type_desc.compare(i - 13, 13, "__attribute__")))) {
+      // Do not bother with function types which return function pointers.
+      if (type_desc.find("(*") >= std::string::size_type(i) &&
+          type_desc.find("(&") >= std::string::size_type(i))
+        ret = i;
+      break;
+    }
+  }
+  return ret;
+}
+}
+
+// Build a detailed function signature, including argument names.
+std::string GetFunctionSignature(IndexFile* db,
+                                 NamespaceHelper* ns,
+                                 const CXIdxDeclInfo* decl) {
+  int num_args = clang_Cursor_getNumArguments(decl->cursor);
+  std::string function_name =
+      ns->QualifiedName(decl->semanticContainer, decl->entityInfo->name);
+
+  std::vector<std::pair<int, std::string>> args;
+  for (int i = 0; i < num_args; i++) {
+    args.emplace_back(-1, ::ToString(clang_getCursorDisplayName(
+                              clang_Cursor_getArgument(decl->cursor, i))));
+  }
+  if (clang_Cursor_isVariadic(decl->cursor)) {
+    args.emplace_back(-1, "");
+    num_args++;
+  }
+
+  std::string type_desc;
+  int function_name_offset;
+#if USE_CLANG_CXX
+  {
+    CXType CT = clang_getCursorType(decl->cursor);
+    QualType T = GetQualType(CT);
+    if (!T.isNull()) {
+      CXTranslationUnit TU = GetTU(CT);
+      SmallString<64> Str;
+      llvm::raw_svector_ostream OS(Str);
+      PrintingPolicy PP(cxtu::getASTUnit(TU)->getASTContext().getLangOpts());
+
+      T.print(OS, PP, "=^_^=");
+      type_desc = OS.str();
+      function_name_offset = type_desc.find("=^_^=");
+      if (type_desc[function_name_offset + 5] != ')')
+        type_desc = type_desc.replace(function_name_offset, 5, "");
+      else {
+        type_desc = type_desc.replace(function_name_offset, 6, "");
+        for (int i = function_name_offset; i-- > 0; )
+          if (type_desc[i] == '(') {
+            type_desc.erase(type_desc.begin() + i);
+            break;
+          }
+        function_name_offset--;
+      }
+    }
+  }
+#else
+  type_desc = ClangCursor(decl->cursor).get_type_description();
+  function_name_offset = GetNameInsertingPosition(type_desc);
+#endif
+
+  if (function_name_offset >= 0) {
+    if (num_args > 0) {
+      // Find positions to insert argument names.
+      // Last argument name is before ')'
+      num_args = 0;
+      // Other argument names come before ','
+      for (int balance = 0, i = function_name_offset;
+           i < int(type_desc.size()) && num_args < int(args.size()); i++) {
+        if (type_desc[i] == '(' || type_desc[i] == '[')
+          balance++;
+        else if (type_desc[i] == ')' || type_desc[i] == ']') {
+          if (--balance <= 0) {
+            args[num_args].first = i;
+            break;
+          }
+        } else if (type_desc[i] == ',' && balance == 1)
+          args[num_args++].first = i;
+      }
+
+      // Second pass: Insert argument names before each comma.
+      int i = 0;
+      std::string type_desc_with_names;
+      for (auto& arg : args) {
+        if (arg.first < 0) {
+          LOG_S(ERROR)
+              << "When adding argument names to '" << type_desc
+              << "', failed to detect positions to insert argument names";
+          break;
+        }
+        if (arg.second.empty())
+          continue;
+        // TODO Use inside-out syntax. Note, clang/lib/AST/TypePrinter.cpp does
+        // not print arg names.
+        type_desc_with_names.insert(type_desc_with_names.end(), &type_desc[i],
+                                    &type_desc[arg.first]);
+        i = arg.first;
+        if (type_desc_with_names.size() &&
+            (type_desc_with_names.back() != ' ' &&
+             type_desc_with_names.back() != '*' &&
+             type_desc_with_names.back() != '&'))
+          type_desc_with_names.push_back(' ');
+        type_desc_with_names.append(arg.second);
+      }
+      type_desc_with_names.insert(type_desc_with_names.end(),
+                                  type_desc.begin() + i, type_desc.end());
+      type_desc = std::move(type_desc_with_names);
+    }
+
+    // TODO auto f() -> int(*)() ; int(*f())()
+    type_desc.insert(function_name_offset, function_name);
+  } else {
+    // type_desc is either a typedef, or some complicated type we cannot handle.
+    // Append the function_name in this case.
+    type_desc.push_back(' ');
+    type_desc.append(function_name);
+  }
+
+  return type_desc;
+}

--- a/src/type_printer.h
+++ b/src/type_printer.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "indexer.h"
+
+std::string GetFunctionSignature(IndexFile* db,
+                                 NamespaceHelper* ns,
+                                 const CXIdxDeclInfo* decl);

--- a/wscript
+++ b/wscript
@@ -226,7 +226,7 @@ def configure(ctx):
 def build(bld):
   cc_files = bld.path.ant_glob(['src/*.cc', 'src/messages/*.cc'])
   if bld.env['use_clang_cxx']:
-    cc_files += bld.path.ant_glob(['src/cxx/*.cc'])
+    cc_files += bld.path.ant_glob(['src/clang_cxx/*.cc'])
 
   lib = []
   if sys.platform.startswith('linux'):
@@ -326,17 +326,19 @@ def build(bld):
       source=cc_files,
       use='clang',
       includes=[
-        #'libclang/',
         'src/',
         'third_party/',
         'third_party/doctest/',
         'third_party/loguru/',
         'third_party/rapidjson/include/',
-        'third_party/sparsepp/'],
-      defines=[#'_GLIBCXX_USE_CXX11_ABI=0',  'clang+llvm-$version-x86_64-linux-gnu-ubuntu-14.04' is pre CXX11_ABI
+        'third_party/sparsepp/'] +
+        (['libclang'] if bld.env['use_clang_cxx'] else []),
+      defines=[
+          #'_GLIBCXX_USE_CXX11_ABI=0',  'clang+llvm-$version-x86_64-linux-gnu-ubuntu-14.04' is pre CXX11_ABI
                #'LOGURU_STACKTRACES=0',
-               'LOGURU_WITH_STREAMS=1',
-               'DEFAULT_RESOURCE_DIRECTORY="' + default_resource_directory + '"'],
+        'LOGURU_WITH_STREAMS=1',
+        'DEFAULT_RESOURCE_DIRECTORY="' + default_resource_directory + '"'] +
+        (['USE_CLANG_CXX=1'] if bld.env['use_clang_cxx'] else []),
       lib=lib,
       rpath=rpath,
       target='bin/cquery')


### PR DESCRIPTION
src/type_printer.cc demonstrates how to leverage clang C++ API

--use-clang-cxx   Use clang C++ API. They might be unstable and should be used with caution.

A copy of latest libclang/ in clang source tree is checked into libclang/ .
These header files are stable and provide some struct definitions used by clang-c/ header files.