### PR TITLE
Reduce queue waiter timeout.

### DIFF
--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -199,8 +199,7 @@ void RunQueryDbThread(const std::string& bin_name,
 
     if (!did_work) {
       auto* queue = QueueManager::instance();
-      waiter->Wait({&QueueManager::instance()->for_querydb, &queue->do_id_map,
-                    &queue->on_indexed});
+      waiter->Wait({&queue->for_querydb, &queue->do_id_map, &queue->on_indexed});
     }
   }
 }

--- a/src/threaded_queue.h
+++ b/src/threaded_queue.h
@@ -36,16 +36,16 @@ struct MultiQueueWaiter {
     // notify. After it is notified we check to see if any of the queues have
     // data; if they do, we return.
     //
-    // We repoll every 5 seconds because it's not possible to atomically check
+    // We repoll every N seconds because it's not possible to atomically check
     // the state of every queue and then setup the condition variable. So, if
     // Wait() is called, HasState() returns false, and then in the time after
     // HasState() is called data gets posted but before we begin waiting for
-    // the condition variable, we will miss the notification. The timeout of 5
-    // means that if this happens we will delay operation for 5 seconds.
+    // the condition variable, we will miss the notification. The timeout of N
+    // means that if this happens we will delay operation for N seconds.
 
     while (!HasState(queues)) {
       std::unique_lock<std::mutex> l(m);
-      cv.wait_for(l, std::chrono::seconds(5));
+      cv.wait_for(l, std::chrono::seconds(1));
     }
   }
 };


### PR DESCRIPTION
The delay mentioned in the comment happens a lot. Maybe because there are multiple queues using the same mutex of waiter. I wonder if it's possible to wait on multiple mutex with variadic template and an iterator version of [std::lock](http://en.cppreference.com/w/cpp/thread/lock). Maybe another `HasState` after `unique_lock` is enough.