### PR TITLE
Fix format with predefined_style when a style cannot be obtained

### DIFF
--- a/src/clang_format.cc
+++ b/src/clang_format.cc
@@ -44,7 +44,7 @@ std::vector<tooling::Replacement> ClangFormatDocument(
   }
 
   auto format_result = reformat(
-      *style, working_file->buffer_content,
+      style ? *style : predefined_style, working_file->buffer_content,
       llvm::ArrayRef<tooling::Range>(tooling::Range(start, end - start)),
       working_file->filename);
   return std::vector<tooling::Replacement>(format_result.begin(),


### PR DESCRIPTION
This fixes a bug when "style" does not have a value and we fallback to "predefined_style".