### PR TITLE
Check __GLIBC__ for malloc_trim instead of __linux__

### DIFF
--- a/src/platform_posix.cc
+++ b/src/platform_posix.cc
@@ -259,7 +259,7 @@ std::vector<std::string> GetPlatformClangArguments() {
 }
 
 void FreeUnusedMemory() {
-#if defined(__linux__)
+#if defined(__GLIBC__)
   malloc_trim(0);
 #endif
 }


### PR DESCRIPTION
Other libc, for example, musl, doesn't have malloc_trim.