### PR TITLE
freeze state of WorkingFiles to insulate them from async changes before shipping unsaved state off to clang

### DIFF
--- a/src/clang_complete.cc
+++ b/src/clang_complete.cc
@@ -298,7 +298,8 @@ void TryEnsureDocumentParsed(ClangCompleteManager* manager,
     args.push_back("-fspell-checking");
   }
 
-  std::vector<CXUnsavedFile> unsaved = session->working_files->AsUnsavedFiles();
+  WorkingFilesSnapshot snapshot = session->working_files->AsSnapshot();
+  std::vector<CXUnsavedFile> unsaved = snapshot.AsUnsavedFiles();
 
   LOG_S(INFO) << "Creating completion session with arguments "
               << StringJoin(args);
@@ -388,8 +389,8 @@ void CompletionQueryMain(ClangCompleteManager* completion_manager) {
     if (!session->tu)
       continue;
 
-    std::vector<CXUnsavedFile> unsaved =
-        completion_manager->working_files_->AsUnsavedFiles();
+    WorkingFilesSnapshot snapshot = completion_manager->working_files_->AsSnapshot();
+    std::vector<CXUnsavedFile> unsaved = snapshot.AsUnsavedFiles();
 
     // Emit code completion data.
     if (request->position) {

--- a/src/working_files.h
+++ b/src/working_files.h
@@ -70,8 +70,15 @@ struct WorkingFile {
   lsPosition FindStableCompletionSource(lsPosition position,
                                         bool* is_global_completion,
                                         std::string* existing_completion) const;
+};
 
-  CXUnsavedFile AsUnsavedFile() const;
+struct WorkingFilesSnapshot {
+  std::vector<CXUnsavedFile> AsUnsavedFiles() const;
+  struct File {
+    std::string filename;
+    std::string content;
+  };
+  std::vector<File> files;
 };
 
 struct WorkingFiles {
@@ -94,7 +101,7 @@ struct WorkingFiles {
   void OnChange(const lsTextDocumentDidChangeParams& change);
   void OnClose(const lsTextDocumentItem& close);
 
-  std::vector<CXUnsavedFile> AsUnsavedFiles();
+  WorkingFilesSnapshot AsSnapshot();
 
   // Use unique_ptrs so we can handout WorkingFile ptrs and not have them
   // invalidated if we resize files.


### PR DESCRIPTION
this is a crude, but empirically effective, attempt to fix https://github.com/jacobdufault/cquery/issues/228 and possibly https://github.com/jacobdufault/cquery/issues/32