### PR TITLE
[comments] Strip additional comment marker at the end of comments

### DIFF
--- a/src/clang_cursor.cc
+++ b/src/clang_cursor.cc
@@ -258,11 +258,13 @@ optional<std::string> ClangCursor::get_comments() const {
   clang_disposeString(cx_raw);
   while (ret.size() && isspace(ret.back()))
     ret.pop_back();
-  if (ret.size() >= 2 && ret.compare(ret.size() - 2, 2, "*/") == 0) {
+  if (EndsWith(ret, "*/")) {
     ret.resize(ret.size() - 2);
-    while (ret.size() && isspace(ret.back()))
-      ret.pop_back();
+  } else if (EndsWith(ret, "\n/")) {
+    ret.resize(ret.size() - 2);
   }
+  while (ret.size() && isspace(ret.back()))
+    ret.pop_back();
   return ret;
 }
 


### PR DESCRIPTION
This strips an additional '/' at the end of comment:
```
  /**
   * name of the network
   **/
  std::string name() const { return name_; }
```
 Before:
```
name of the network
/
```
After:
```
name of the network
```