### PR TITLE
fix logic in GetFilesInFolderHelper from DFS-ification in 96f4ffc4b

### DIFF
--- a/src/utils.cc
+++ b/src/utils.cc
@@ -167,7 +167,7 @@ static void GetFilesInFolderHelper(
       if (file.name[0] != '.') {
         if (file.is_dir) {
           if (recursive) {
-            std::string child_dir = output_prefix + file.name + "/";
+            std::string child_dir = q.front().second + file.name + "/";
             if (!IsSymLink(child_dir))
               q.push(make_pair(file.path, child_dir));
           }


### PR DESCRIPTION
clear break from noted commit; manifests itself if subdirectory tree has depth >1 in a project.