### PR TITLE
Don't extent region of constructor.

### DIFF
--- a/src/message_handler.cc
+++ b/src/message_handler.cc
@@ -121,6 +121,17 @@ void EmitSemanticHighlighting(QueryDatabase* db,
           continue;  // applies to for loop
         is_type_member = func->def->declaring_type.has_value();
         detailed_name = func->def->short_name;
+        // shrink location region
+        auto concise_name = detailed_name.substr(0, detailed_name.find('<'));
+        std::string& line =
+            working_file->index_lines[sym.loc.range.start.line - 1];
+        auto pos = line.find(concise_name);
+        sym.loc.range.end.line = sym.loc.range.start.line;
+        if (pos == std::string::npos)
+          sym.loc.range.end.column = sym.loc.range.start.column;
+        else
+          sym.loc.range.end.column =
+              sym.loc.range.start.column + concise_name.size();
         break;
       }
       case SymbolKind::Var: {


### PR DESCRIPTION
A hack to make the semantic highlight of lambda body correct in the parameter region of a constructor function.

Before:
![before](https://user-images.githubusercontent.com/320163/34711718-541c7ad0-f55b-11e7-8519-96f652e30458.png)

After:
![after](https://user-images.githubusercontent.com/320163/34711725-5b7b399c-f55b-11e7-93dc-0631aa154ce7.png)
