### PR TITLE
fix for 5859424d: do not include extensionless files in directory scan

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -266,7 +266,7 @@ std::vector<Project::Entry> LoadFromDirectoryListing(ProjectConfig* config) {
   std::vector<std::string> files = GetFilesInFolder(
       config->project_dir, true /*recursive*/, true /*add_folder_to_path*/);
   for (const std::string& file : files) {
-    if (SourceFileType(file)) {
+    if (file.find('.') != std::string::npos && SourceFileType(file)) {
       CompileCommandsEntry e;
       e.directory = config->project_dir;
       e.file = file;


### PR DESCRIPTION
i _think_ this preserves what the change was intended to do, without the side-effect of trying to index every extensionless file when doing the directory scan when using a `.cquery` config.