### PR TITLE
Only shell out to llvm-config if the configure step found it

### DIFF
--- a/wscript
+++ b/wscript
@@ -304,9 +304,12 @@ def build(bld):
     lib.append('ncurses')
 
   if bld.env['use_system_clang']:
-    rpath = str(subprocess.check_output(
+    if bld.env['llvm_config']:
+      rpath = str(subprocess.check_output(
         [bld.env['llvm_config'], '--libdir'],
         stderr=subprocess.STDOUT).decode()).strip()
+    else:
+      rpath = []
 
     # Use CXX set by --check-cxx-compiler if it is "clang".
     # See https://github.com/jacobdufault/cquery/issues/237


### PR DESCRIPTION
This addresses a defect in c9c3cfb624fa2f55513955f82c579b9ca5240b52