### PR TITLE
Add missing #includes

### DIFF
--- a/src/language_server_api.h
+++ b/src/language_server_api.h
@@ -11,6 +11,8 @@
 #include <variant.h>
 
 #include <algorithm>
+#include <iostream>
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 


### PR DESCRIPTION
Without these includes back, I cannot compile `language_server_api.h` locally.