### PR TITLE
Fix autocompletion results on semicolon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ waf-*
 waf2*
 waf3*
 x64
+cquery_log.txt

--- a/src/messages/text_document_completion.cc
+++ b/src/messages/text_document_completion.cc
@@ -296,6 +296,14 @@ struct TextDocumentCompletionHandler : MessageHandler {
             out.result.items = results;
 
             // Emit completion results.
+            if (existing_completion.size()==0 && is_global_completion) {
+              LOG_S(INFO) << "Existing completion is empty, no completion results will be returned";
+              Out_TextDocumentComplete out;
+              out.id = request->id;
+              QueueManager::WriteStdout(IpcId::TextDocumentCompletion, out);
+              return;
+            }
+            
             SortAndFilterCompletionResponse(&out, existing_completion);
             QueueManager::WriteStdout(IpcId::TextDocumentCompletion, out);
 

--- a/src/messages/text_document_completion.cc
+++ b/src/messages/text_document_completion.cc
@@ -291,12 +291,11 @@ struct TextDocumentCompletionHandler : MessageHandler {
           [this, is_global_completion, existing_completion, request](
               const std::vector<lsCompletionItem>& results,
               bool is_cached_result) {
-            Out_TextDocumentComplete out;
-            out.id = request->id;
-            out.result.items = results;
-
-            // Emit completion results.
-            if (existing_completion.empty() && is_global_completion) {
+            //If existing completion is empty, dont return completion results
+            //Only do this when trigger is not manual and context doesn't exist
+            //(for Atom support)
+            if (existing_completion.empty() && is_global_completion && !(request->params.context) &&
+              request->params.context->triggerKind == lsCompletionTriggerKind::TriggerCharacter) {
               LOG_S(INFO) << "Existing completion is empty, no completion results will be returned";
               Out_TextDocumentComplete out;
               out.id = request->id;
@@ -304,6 +303,11 @@ struct TextDocumentCompletionHandler : MessageHandler {
               return;
             }
 
+            Out_TextDocumentComplete out;
+            out.id = request->id;
+            out.result.items = results;
+
+            // Emit completion results.
             SortAndFilterCompletionResponse(&out, existing_completion);
             QueueManager::WriteStdout(IpcId::TextDocumentCompletion, out);
 

--- a/src/messages/text_document_completion.cc
+++ b/src/messages/text_document_completion.cc
@@ -253,6 +253,26 @@ struct TextDocumentCompletionHandler : MessageHandler {
       }
     }
 
+    bool is_global_completion = false;
+    std::string existing_completion;
+    if (file) {
+      request->params.position = file->FindStableCompletionSource(
+          request->params.position, &is_global_completion,
+          &existing_completion);
+    }
+    
+    //If existing completion is empty, dont return completion results
+    //Only do this when trigger is not manual or context doesn't exist
+    //(for Atom support)
+    if (existing_completion.empty() && is_global_completion && (!(request->params.context) ||
+      request->params.context->triggerKind == lsCompletionTriggerKind::TriggerCharacter)) {
+      LOG_S(INFO) << "Existing completion is empty, no completion results will be returned";
+      Out_TextDocumentComplete out;
+      out.id = request->id;
+      QueueManager::WriteStdout(IpcId::TextDocumentCompletion, out);
+      return;
+    }
+
     if (ShouldRunIncludeCompletion(buffer_line)) {
       Out_TextDocumentComplete out;
       out.id = request->id;
@@ -279,30 +299,10 @@ struct TextDocumentCompletionHandler : MessageHandler {
       SortAndFilterCompletionResponse(&out, buffer_line);
       QueueManager::WriteStdout(IpcId::TextDocumentCompletion, out);
     } else {
-      bool is_global_completion = false;
-      std::string existing_completion;
-      if (file) {
-        request->params.position = file->FindStableCompletionSource(
-            request->params.position, &is_global_completion,
-            &existing_completion);
-      }
-
       ClangCompleteManager::OnComplete callback = std::bind(
           [this, is_global_completion, existing_completion, request](
               const std::vector<lsCompletionItem>& results,
               bool is_cached_result) {
-            //If existing completion is empty, dont return completion results
-            //Only do this when trigger is not manual and context doesn't exist
-            //(for Atom support)
-            if (existing_completion.empty() && is_global_completion && !(request->params.context) &&
-              request->params.context->triggerKind == lsCompletionTriggerKind::TriggerCharacter) {
-              LOG_S(INFO) << "Existing completion is empty, no completion results will be returned";
-              Out_TextDocumentComplete out;
-              out.id = request->id;
-              QueueManager::WriteStdout(IpcId::TextDocumentCompletion, out);
-              return;
-            }
-
             Out_TextDocumentComplete out;
             out.id = request->id;
             out.result.items = results;

--- a/src/messages/text_document_completion.cc
+++ b/src/messages/text_document_completion.cc
@@ -296,14 +296,14 @@ struct TextDocumentCompletionHandler : MessageHandler {
             out.result.items = results;
 
             // Emit completion results.
-            if (existing_completion.size()==0 && is_global_completion) {
+            if (existing_completion.empty() && is_global_completion) {
               LOG_S(INFO) << "Existing completion is empty, no completion results will be returned";
               Out_TextDocumentComplete out;
               out.id = request->id;
               QueueManager::WriteStdout(IpcId::TextDocumentCompletion, out);
               return;
             }
-            
+
             SortAndFilterCompletionResponse(&out, existing_completion);
             QueueManager::WriteStdout(IpcId::TextDocumentCompletion, out);
 


### PR DESCRIPTION
Fixing a bug where autocomplete results would be shown in Atom when typing `;` or even an empty space.