### PR TITLE
Don't give up index files of headers if the .cc/.cpp file failed.

### DIFF
--- a/src/import_pipeline.cc
+++ b/src/import_pipeline.cc
@@ -129,8 +129,6 @@ std::vector<Index_DoIdMap> DoParseFile(
       if (!last_cached_modification ||
           modification_timestamp != *last_cached_modification) {
         file_consumer_shared->Reset(path);
-        timestamp_manager->UpdateCachedModificationTime(
-            path, *modification_timestamp);
         return FileParseQuery::NeedsParse;
       }
 

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1981,7 +1981,6 @@ std::vector<std::unique_ptr<IndexFile>> ParseWithTu(
   if (index_result != CXError_Success) {
     LOG_S(WARNING) << "Indexing " << file
                    << " failed with errno=" << index_result;
-    return {};
   }
 
   clang_IndexAction_dispose(index_action);


### PR DESCRIPTION
Otherwise these headers are marked in global file consumer and no other index files will be generated.

That `UpdateCachedModificationTime` seems to be not needed. Not sure about the `Reset` in the previous line.