### PR TITLE
Response on index error.

### DIFF
--- a/src/iindexer.cc
+++ b/src/iindexer.cc
@@ -6,7 +6,7 @@ namespace {
 struct ClangIndexer : IIndexer {
   ~ClangIndexer() override = default;
 
-  std::vector<std::unique_ptr<IndexFile>> Index(
+  optional<std::vector<std::unique_ptr<IndexFile>>> Index(
       Config* config,
       FileConsumerSharedState* file_consumer_shared,
       std::string file,
@@ -50,7 +50,7 @@ struct TestIndexer : IIndexer {
 
   ~TestIndexer() override = default;
 
-  std::vector<std::unique_ptr<IndexFile>> Index(
+  optional<std::vector<std::unique_ptr<IndexFile>>> Index(
       Config* config,
       FileConsumerSharedState* file_consumer_shared,
       std::string file,
@@ -61,7 +61,7 @@ struct TestIndexer : IIndexer {
     if (it == indexes.end()) {
       // Don't return any indexes for unexpected data.
       assert(false && "no indexes");
-      return {};
+      return nullopt;
     }
 
     // FIXME: allow user to control how many times we return the index for a

--- a/src/iindexer.h
+++ b/src/iindexer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional.h>
+
 #include <initializer_list>
 #include <memory>
 #include <string>
@@ -32,7 +34,7 @@ struct IIndexer {
       std::initializer_list<TestEntry> entries);
 
   virtual ~IIndexer() = default;
-  virtual std::vector<std::unique_ptr<IndexFile>> Index(
+  virtual optional<std::vector<std::unique_ptr<IndexFile>>> Index(
       Config* config,
       FileConsumerSharedState* file_consumer_shared,
       std::string file,

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1894,7 +1894,7 @@ void OnIndexReference(CXClientData client_data, const CXIdxEntityRefInfo* ref) {
   }
 }
 
-std::vector<std::unique_ptr<IndexFile>> Parse(
+optional<std::vector<std::unique_ptr<IndexFile>>> Parse(
     Config* config,
     FileConsumerSharedState* file_consumer_shared,
     std::string file,
@@ -1924,7 +1924,7 @@ std::vector<std::unique_ptr<IndexFile>> Parse(
       CXTranslationUnit_KeepGoing |
           CXTranslationUnit_DetailedPreprocessingRecord);
   if (!tu)
-    return {};
+    return nullopt;
 
   perf->index_parse = timer.ElapsedMicrosecondsAndReset();
 
@@ -1935,7 +1935,7 @@ std::vector<std::unique_ptr<IndexFile>> Parse(
                      unsaved_files);
 }
 
-std::vector<std::unique_ptr<IndexFile>> ParseWithTu(
+optional<std::vector<std::unique_ptr<IndexFile>>> ParseWithTu(
     FileConsumerSharedState* file_consumer_shared,
     PerformanceImportFile* perf,
     ClangTranslationUnit* tu,
@@ -1982,8 +1982,9 @@ std::vector<std::unique_ptr<IndexFile>> ParseWithTu(
           CXIndexOpt_IndexImplicitTemplateInstantiations,
       tu->cx_tu);
   if (index_result != CXError_Success) {
-    LOG_S(WARNING) << "Indexing " << file
-                   << " failed with errno=" << index_result;
+    LOG_S(ERROR) << "Indexing " << file
+                 << " failed with errno=" << index_result;
+    return nullopt;
   }
 
   clang_IndexAction_dispose(index_action);

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -539,7 +539,7 @@ struct NamespaceHelper {
 // |desired_index_file| is the (h or cc) file which has actually changed.
 // |dependencies| are the existing dependencies of |import_file| if this is a
 // reparse.
-std::vector<std::unique_ptr<IndexFile>> Parse(
+optional<std::vector<std::unique_ptr<IndexFile>>> Parse(
     Config* config,
     FileConsumerSharedState* file_consumer_shared,
     std::string file,
@@ -548,7 +548,7 @@ std::vector<std::unique_ptr<IndexFile>> Parse(
     PerformanceImportFile* perf,
     ClangIndex* index,
     bool dump_ast = false);
-std::vector<std::unique_ptr<IndexFile>> ParseWithTu(
+optional<std::vector<std::unique_ptr<IndexFile>>> ParseWithTu(
     FileConsumerSharedState* file_consumer_shared,
     PerformanceImportFile* perf,
     ClangTranslationUnit* tu,

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -221,8 +221,9 @@ struct InitializeHandler : BaseMessageHandler<Ipc_InitializeRequest> {
             }
             bool is_interactive =
                 working_files->GetFileByFilename(entry.filename) != nullptr;
-            queue->index_request.Enqueue(Index_Request(
-                entry.filename, entry.args, is_interactive, *content));
+            queue->index_request.Enqueue(
+                Index_Request(entry.filename, entry.args, is_interactive,
+                              *content, request->id));
           });
 
       // We need to support multiple concurrent index processes.

--- a/src/queue_manager.cc
+++ b/src/queue_manager.cc
@@ -8,11 +8,13 @@
 Index_Request::Index_Request(const std::string& path,
                              const std::vector<std::string>& args,
                              bool is_interactive,
-                             const std::string& contents)
+                             const std::string& contents,
+                             lsRequestId id)
     : path(path),
       args(args),
       is_interactive(is_interactive),
-      contents(contents) {}
+      contents(contents),
+      id(id) {}
 
 Index_DoIdMap::Index_DoIdMap(std::unique_ptr<IndexFile> current,
                              PerformanceImportFile perf,

--- a/src/queue_manager.h
+++ b/src/queue_manager.h
@@ -20,11 +20,13 @@ struct Index_Request {
   std::vector<std::string> args;
   bool is_interactive;
   std::string contents;  // Preloaded contents. Useful for tests.
+  lsRequestId id;
 
   Index_Request(const std::string& path,
                 const std::vector<std::string>& args,
                 bool is_interactive,
-                const std::string& contents);
+                const std::string& contents,
+                lsRequestId id={});
 };
 
 struct Index_DoIdMap {

--- a/src/test.cc
+++ b/src/test.cc
@@ -170,9 +170,9 @@ bool RunIndexTests(const std::string& filter_path, bool enable_update) {
     Config config;
     FileConsumerSharedState file_consumer_shared;
     PerformanceImportFile perf;
-    std::vector<std::unique_ptr<IndexFile>> dbs =
-        Parse(&config, &file_consumer_shared, path, flags, {}, &perf, &index,
-              false /*dump_ast*/);
+    auto dbs = Parse(&config, &file_consumer_shared, path, flags, {}, &perf,
+                     &index, false /*dump_ast*/);
+    assert(dbs);
 
     for (const auto& entry : all_expected_output) {
       const std::string& expected_path = entry.first;
@@ -203,7 +203,7 @@ bool RunIndexTests(const std::string& filter_path, bool enable_update) {
       };
 
       // Get output from index operation.
-      IndexFile* db = FindDbForPathEnding(expected_path, dbs);
+      IndexFile* db = FindDbForPathEnding(expected_path, *dbs);
       assert(db);
       if (!db->diagnostics_.empty()) {
         std::cout << "For " << path << std::endl;


### PR DESCRIPTION
I think users should be aware of index errors before they post issues. It's also easier for developers to notice the problem rather than diving into the log file.

Cquery should have better index failure mechanism. For now, if bad thing happened, all files are already marked in global file consumer and no other indexes of them will be generated. Letting go the already generated index files is also not appropriate because they may have not gone through all the `on*` functions. I have also tried to unmark these files in global file consumer. But if the error occurs in a deep include file, almost all index attempts will fail. Any way, one failure should influence least the entire task. However, it does not appear to be easy nowadays.