### PR TITLE
Remove unused variable `ex` in initialize.cc

### DIFF
--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -496,7 +496,7 @@ struct InitializeHandler : BaseMessageHandler<Ipc_InitializeRequest> {
           JsonReader json_reader{&reader};
           try {
             Reflect(json_reader, *config);
-          } catch (std::invalid_argument& ex) {
+          } catch (std::invalid_argument&) {
             // This will not trigger because parse error is handled in
             // MessageRegistry::Parse in language_server_api.cc
           }


### PR DESCRIPTION
... which leads to a compile error in MSVC.