### PR TITLE
Return a standards-compliant :textDocument/documentHighlight reply

### DIFF
--- a/src/messages/text_document_document_highlight.cc
+++ b/src/messages/text_document_document_highlight.cc
@@ -54,7 +54,6 @@ struct Handler_TextDocumentDocumentHighlight
             highlight.kind = lsDocumentHighlightKind::Read;
           else
             highlight.kind = lsDocumentHighlightKind::Text;
-          highlight.role = use.role;
           out.result.push_back(highlight);
         }
       });

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -74,11 +74,8 @@ struct lsDocumentHighlight {
 
   // The highlight kind, default is DocumentHighlightKind.Text.
   lsDocumentHighlightKind kind = lsDocumentHighlightKind::Text;
-
-  // cquery extension
-  Role role = Role::None;
 };
-MAKE_REFLECT_STRUCT(lsDocumentHighlight, range, kind, role);
+MAKE_REFLECT_STRUCT(lsDocumentHighlight, range, kind);
 
 struct lsSymbolInformation {
   std::string_view name;


### PR DESCRIPTION
If discussion in #682 turns up any users of this, then I'll drop this PR and instead document the quirk somewhere in the cquery wiki.

---

Prevents an editor's language server client from choking on a JSON
RPC reply with unexpected arguments. There appear to be no current
users of this protocol extension, so removing it shouldn't cause any
regressions.

Fixes #682.